### PR TITLE
구독 기능 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id "org.sonarqube" version "3.4.0.2513"
     id "jacoco"
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'com.rssmanager'
@@ -27,6 +28,9 @@ repositories {
 }
 
 dependencies {
+    implementation 'com.querydsl:querydsl-jpa:5.0.0'
+    implementation 'com.querydsl:querydsl-apt:5.0.0'
+
     testImplementation 'io.rest-assured:rest-assured:4.4.0'
     testImplementation 'io.rest-assured:spring-mock-mvc:4.4.0'
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
@@ -105,4 +109,23 @@ jacocoTestReport {
     reports {
         xml.enabled true
     }
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+
+sourceSets {
+    main.java.srcDir querydslDir
+}
+
+configurations {
+    querydsl.extendsFrom compileClasspath
+}
+
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
 }

--- a/backend/src/main/java/com/rssmanager/config/QuerydslConfig.java
+++ b/backend/src/main/java/com/rssmanager/config/QuerydslConfig.java
@@ -1,0 +1,18 @@
+package com.rssmanager.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/backend/src/main/java/com/rssmanager/exception/BadRequestException.java
+++ b/backend/src/main/java/com/rssmanager/exception/BadRequestException.java
@@ -10,4 +10,8 @@ public class BadRequestException extends MyRSSException {
     public BadRequestException(final String message) {
         super(message);
     }
+
+    public BadRequestException(final String message, final Exception e) {
+        super(message, e);
+    }
 }

--- a/backend/src/main/java/com/rssmanager/exception/InvalidRssUrlException.java
+++ b/backend/src/main/java/com/rssmanager/exception/InvalidRssUrlException.java
@@ -1,0 +1,8 @@
+package com.rssmanager.exception;
+
+public class InvalidRssUrlException extends BadRequestException {
+
+    public InvalidRssUrlException(final Exception e) {
+        super(e.getMessage(), e);
+    }
+}

--- a/backend/src/main/java/com/rssmanager/exception/MyRSSException.java
+++ b/backend/src/main/java/com/rssmanager/exception/MyRSSException.java
@@ -5,4 +5,9 @@ public class MyRSSException extends RuntimeException {
     public MyRSSException(final String message) {
         super(message);
     }
+
+
+    public MyRSSException(final String message, final Exception e) {
+        super(message, e);
+    }
 }

--- a/backend/src/main/java/com/rssmanager/rss/controller/SubscribeController.java
+++ b/backend/src/main/java/com/rssmanager/rss/controller/SubscribeController.java
@@ -1,0 +1,32 @@
+package com.rssmanager.rss.controller;
+
+import com.rssmanager.auth.annotation.LoginMember;
+import com.rssmanager.member.domain.Member;
+import com.rssmanager.rss.controller.dto.SubscribeRequest;
+import com.rssmanager.rss.controller.dto.SubscribeResponse;
+import com.rssmanager.rss.service.SubscribeService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/subscribes")
+@RestController
+public class SubscribeController {
+    private final SubscribeService subscribeService;
+
+    public SubscribeController(final SubscribeService subscribeService) {
+        this.subscribeService = subscribeService;
+    }
+
+    @PostMapping
+    public ResponseEntity<SubscribeResponse> subscribe(@LoginMember final Member member,
+                                                       @RequestBody final SubscribeRequest subscribeRequest) {
+        final var subscribeResult = subscribeService.subscribe(member, subscribeRequest);
+        return ResponseEntity.ok(SubscribeResponse.from(subscribeResult));
+    }
+
+//    @GetMapping
+//    public ResponseEntity<Subscribe>
+}

--- a/backend/src/main/java/com/rssmanager/rss/controller/SubscribeController.java
+++ b/backend/src/main/java/com/rssmanager/rss/controller/SubscribeController.java
@@ -2,10 +2,13 @@ package com.rssmanager.rss.controller;
 
 import com.rssmanager.auth.annotation.LoginMember;
 import com.rssmanager.member.domain.Member;
+import com.rssmanager.rss.controller.dto.FeedResponses;
 import com.rssmanager.rss.controller.dto.SubscribeRequest;
 import com.rssmanager.rss.controller.dto.SubscribeResponse;
 import com.rssmanager.rss.service.SubscribeService;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,6 +30,10 @@ public class SubscribeController {
         return ResponseEntity.ok(SubscribeResponse.from(subscribeResult));
     }
 
-//    @GetMapping
-//    public ResponseEntity<Subscribe>
+    @GetMapping
+    public ResponseEntity<FeedResponses> readSubscribedFeeds(@LoginMember final Member member,
+                                                             final Pageable pageable) {
+        final var feedResponses = subscribeService.findSubscribedFeeds(member, pageable);
+        return ResponseEntity.ok(feedResponses);
+    }
 }

--- a/backend/src/main/java/com/rssmanager/rss/controller/dto/SubscribeRequest.java
+++ b/backend/src/main/java/com/rssmanager/rss/controller/dto/SubscribeRequest.java
@@ -1,0 +1,15 @@
+package com.rssmanager.rss.controller.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SubscribeRequest {
+    private String url;
+
+    public SubscribeRequest() {
+    }
+
+    public SubscribeRequest(final String url) {
+        this.url = url;
+    }
+}

--- a/backend/src/main/java/com/rssmanager/rss/controller/dto/SubscribeResponse.java
+++ b/backend/src/main/java/com/rssmanager/rss/controller/dto/SubscribeResponse.java
@@ -1,0 +1,16 @@
+package com.rssmanager.rss.controller.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SubscribeResponse {
+    private final Long id;
+
+    public SubscribeResponse(final Long id) {
+        this.id = id;
+    }
+
+    public static SubscribeResponse from(final Long id) {
+        return new SubscribeResponse(id);
+    }
+}

--- a/backend/src/main/java/com/rssmanager/rss/domain/Rss.java
+++ b/backend/src/main/java/com/rssmanager/rss/domain/Rss.java
@@ -23,11 +23,13 @@ public class Rss {
     }
 
     @Builder
-    public Rss(final Long id, final String title, final String rssUrl, final String link, final String iconUrl) {
+    public Rss(final Long id, final String title, final String rssUrl, final String link, final String iconUrl,
+               final boolean recommended) {
         this.id = id;
         this.title = title;
         this.rssUrl = rssUrl;
         this.link = link;
         this.iconUrl = iconUrl;
+        this.recommended = recommended;
     }
 }

--- a/backend/src/main/java/com/rssmanager/rss/domain/Rss.java
+++ b/backend/src/main/java/com/rssmanager/rss/domain/Rss.java
@@ -17,19 +17,17 @@ public class Rss {
     private String rssUrl;
     private String link;
     private String iconUrl;
-    private boolean recommended;
+    private boolean recommended = false;
 
     protected Rss() {
     }
 
     @Builder
-    public Rss(final Long id, final String title, final String rssUrl, final String link, final String iconUrl,
-               final boolean recommended) {
+    public Rss(final Long id, final String title, final String rssUrl, final String link, final String iconUrl) {
         this.id = id;
         this.title = title;
         this.rssUrl = rssUrl;
         this.link = link;
         this.iconUrl = iconUrl;
-        this.recommended = recommended;
     }
 }

--- a/backend/src/main/java/com/rssmanager/rss/domain/Subscribe.java
+++ b/backend/src/main/java/com/rssmanager/rss/domain/Subscribe.java
@@ -1,0 +1,37 @@
+package com.rssmanager.rss.domain;
+
+import com.rssmanager.member.domain.Member;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Entity
+public class Subscribe {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "memberId")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "rssId")
+    private Rss rss;
+
+    public Subscribe() {
+    }
+
+    @Builder
+    public Subscribe(final Member member, final Rss rss) {
+        this.member = member;
+        this.rss = rss;
+    }
+}

--- a/backend/src/main/java/com/rssmanager/rss/repository/SubscribeRepository.java
+++ b/backend/src/main/java/com/rssmanager/rss/repository/SubscribeRepository.java
@@ -1,8 +1,14 @@
 package com.rssmanager.rss.repository;
 
 import com.rssmanager.rss.domain.Subscribe;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
 
 public interface SubscribeRepository extends Repository<Subscribe, Long> {
     Subscribe save(Subscribe subscribe);
+
+    @Query("select s.id from Subscribe s where s.rss.id = :rssId and s.member.id = :memberId")
+    Optional<Long> findIdByRssIdAndMemberId(@Param("rssId") Long rssId, @Param("memberId") Long memberId);
 }

--- a/backend/src/main/java/com/rssmanager/rss/repository/SubscribeRepository.java
+++ b/backend/src/main/java/com/rssmanager/rss/repository/SubscribeRepository.java
@@ -1,0 +1,8 @@
+package com.rssmanager.rss.repository;
+
+import com.rssmanager.rss.domain.Subscribe;
+import org.springframework.data.repository.Repository;
+
+public interface SubscribeRepository extends Repository<Subscribe, Long> {
+    Subscribe save(Subscribe subscribe);
+}

--- a/backend/src/main/java/com/rssmanager/rss/service/JpaRssService.java
+++ b/backend/src/main/java/com/rssmanager/rss/service/JpaRssService.java
@@ -39,14 +39,7 @@ public class JpaRssService implements RssService {
             throw new RuntimeException(e);
         }
 
-        final var newRssToSave = Rss.builder()
-                .title(feeds.getTitle())
-                .rssUrl(rssCreateRequest.getRssUrl())
-                .link(feeds.getUri())
-                .iconUrl(findIconUrl(feeds))
-                .recommended(false)
-                .build();
-
+        final var newRssToSave = buildRss(rssCreateRequest, feeds);
         return rssRepository.save(newRssToSave);
     }
 
@@ -56,5 +49,14 @@ public class JpaRssService implements RssService {
         }
 
         return feeds.getIcon().getLink();
+    }
+
+    private Rss buildRss(final RssCreateRequest rssCreateRequest, final SyndFeed feeds) {
+        return Rss.builder()
+                .title(feeds.getTitle())
+                .rssUrl(rssCreateRequest.getRssUrl())
+                .link(feeds.getUri())
+                .iconUrl(findIconUrl(feeds))
+                .build();
     }
 }

--- a/backend/src/main/java/com/rssmanager/rss/service/JpaSubscribeService.java
+++ b/backend/src/main/java/com/rssmanager/rss/service/JpaSubscribeService.java
@@ -1,0 +1,57 @@
+package com.rssmanager.rss.service;
+
+import com.rssmanager.member.domain.Member;
+import com.rssmanager.rss.controller.dto.SubscribeRequest;
+import com.rssmanager.rss.repository.FeedRepository;
+import com.rssmanager.rss.repository.RssRepository;
+import com.rssmanager.rss.repository.SubscribeRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@Service
+public class JpaSubscribeService implements SubscribeService {
+    private final SubscribeRepository subscribeRepository;
+    private final FeedRepository feedRepository;
+    private final RssRepository rssRepository;
+
+    public JpaSubscribeService(final SubscribeRepository subscribeRepository, final FeedRepository feedRepository,
+                               final RssRepository rssRepository) {
+        this.subscribeRepository = subscribeRepository;
+        this.feedRepository = feedRepository;
+        this.rssRepository = rssRepository;
+    }
+
+    @Transactional
+    @Override
+    public Long subscribe(final Member member, final SubscribeRequest subscribeRequest) {
+        final var requestUrl = subscribeRequest.getUrl();
+        // 등록된 RSS인지 확인하고 등록되어 있다면 구독리포에 저장하고 리턴하면 끝이다.
+        // 처음 등록하는 RSS이면 RSS 저장, Feed저장, 구독 저장 셋다해야한다.
+//
+//        final Optional<Rss> byRssUrl = rssRepository.findByRssUrl(requestUrl);
+//        if (byRssUrl.isPresent()) {
+//            final var subscribe = subscribeRepository.save(new Subscribe(member, byRssUrl.get()));
+//            return subscribe.getId();
+//        }
+//
+//        final var newFeedsToSave = new ArrayList<Feed>();
+//
+//        final SyndFeed feeds;
+//        try {
+//            feeds = new SyndFeedInput().build(new XmlReader(new URL(requestUrl)));
+//        } catch (FeedException | IOException e) {
+//            throw new RuntimeException(e);
+//        }
+//        final var newFeeds = filterNewFeeds(rss, feeds);
+//        newFeedsToSave.addAll(newFeeds);
+//
+//        if (newFeedsToSave.isEmpty()) {
+//            return;
+//        }
+//        rssRepository.saveAll(newFeedsToSave);
+//
+//        subscribeRepository.save(new Sub)
+        return null;
+    }
+}

--- a/backend/src/main/java/com/rssmanager/rss/service/JpaSubscribeService.java
+++ b/backend/src/main/java/com/rssmanager/rss/service/JpaSubscribeService.java
@@ -1,12 +1,34 @@
 package com.rssmanager.rss.service;
 
+import static com.rssmanager.rss.domain.QFeed.feed;
+import static com.rssmanager.rss.domain.QSubscribe.subscribe;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.rometools.rome.feed.synd.SyndEntry;
+import com.rometools.rome.feed.synd.SyndFeed;
+import com.rometools.rome.io.SyndFeedInput;
+import com.rometools.rome.io.XmlReader;
+import com.rssmanager.exception.InvalidRssUrlException;
 import com.rssmanager.member.domain.Member;
+import com.rssmanager.rss.controller.dto.FeedResponse;
+import com.rssmanager.rss.controller.dto.FeedResponses;
 import com.rssmanager.rss.controller.dto.SubscribeRequest;
+import com.rssmanager.rss.domain.Feed;
+import com.rssmanager.rss.domain.Rss;
+import com.rssmanager.rss.domain.Subscribe;
 import com.rssmanager.rss.repository.FeedRepository;
 import com.rssmanager.rss.repository.RssRepository;
 import com.rssmanager.rss.repository.SubscribeRepository;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @Transactional(readOnly = true)
 @Service
@@ -14,44 +36,158 @@ public class JpaSubscribeService implements SubscribeService {
     private final SubscribeRepository subscribeRepository;
     private final FeedRepository feedRepository;
     private final RssRepository rssRepository;
+    private final JPAQueryFactory jpaQueryFactory;
 
     public JpaSubscribeService(final SubscribeRepository subscribeRepository, final FeedRepository feedRepository,
-                               final RssRepository rssRepository) {
+                               final RssRepository rssRepository, final JPAQueryFactory jpaQueryFactory) {
         this.subscribeRepository = subscribeRepository;
         this.feedRepository = feedRepository;
         this.rssRepository = rssRepository;
+        this.jpaQueryFactory = jpaQueryFactory;
     }
 
     @Transactional
     @Override
     public Long subscribe(final Member member, final SubscribeRequest subscribeRequest) {
-        final var requestUrl = subscribeRequest.getUrl();
-        // 등록된 RSS인지 확인하고 등록되어 있다면 구독리포에 저장하고 리턴하면 끝이다.
-        // 처음 등록하는 RSS이면 RSS 저장, Feed저장, 구독 저장 셋다해야한다.
-//
-//        final Optional<Rss> byRssUrl = rssRepository.findByRssUrl(requestUrl);
-//        if (byRssUrl.isPresent()) {
-//            final var subscribe = subscribeRepository.save(new Subscribe(member, byRssUrl.get()));
-//            return subscribe.getId();
-//        }
-//
-//        final var newFeedsToSave = new ArrayList<Feed>();
-//
-//        final SyndFeed feeds;
-//        try {
-//            feeds = new SyndFeedInput().build(new XmlReader(new URL(requestUrl)));
-//        } catch (FeedException | IOException e) {
-//            throw new RuntimeException(e);
-//        }
-//        final var newFeeds = filterNewFeeds(rss, feeds);
-//        newFeedsToSave.addAll(newFeeds);
-//
-//        if (newFeedsToSave.isEmpty()) {
-//            return;
-//        }
-//        rssRepository.saveAll(newFeedsToSave);
-//
-//        subscribeRepository.save(new Sub)
-        return null;
+        final var requestUrl = getRequestedRssUrl(subscribeRequest.getUrl());
+
+        final var foundRss = rssRepository.findByRssUrl(requestUrl);
+        if (foundRss.isPresent()) {
+            return registerSubscribe(member, foundRss.get());
+        }
+
+        final var feedInfo = fetchFeeds(requestUrl);
+        final var savedRss = rssRepository.save(buildRss(feedInfo, requestUrl));
+        feedRepository.saveAll(convertFeed(feedInfo, savedRss));
+
+        return subscribeRepository.save(new Subscribe(member, savedRss)).getId();
+    }
+
+    @Override
+    public FeedResponses findSubscribedFeeds(final Member member, final Pageable pageable) {
+        final var subscribedFeeds = jpaQueryFactory.selectFrom(feed)
+                .leftJoin(subscribe).on(feed.rss.id.eq(subscribe.rss.id))
+                .where(subscribe.member.id.eq(member.getId()))
+                .orderBy(feed.updateDate.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch()
+                .stream()
+                .map(FeedResponse::from)
+                .collect(Collectors.toList());
+
+        final var hasNext = subscribedFeeds.size() > pageable.getPageSize();
+        final int pageNumber = pageable.getPageNumber();
+
+        return FeedResponses.builder()
+                .feedResponses(subscribedFeeds)
+                .hasNext(hasNext)
+                .nextPageable(pageable.withPage(hasNext ? pageNumber + 1 : pageNumber))
+                .build();
+    }
+
+    private String getRequestedRssUrl(final String url) {
+        if (url.endsWith("/")) {
+            return url.substring(0, url.length() - 1);
+        }
+
+        return url;
+    }
+
+    private Long registerSubscribe(final Member member, final Rss rss) {
+        final var id = subscribeRepository.findIdByRssIdAndMemberId(rss.getId(), member.getId());
+        if (id.isPresent()) {
+            return id.get();
+        }
+
+        final var subscribe = new Subscribe(member, rss);
+        final var savedSubscribe = subscribeRepository.save(subscribe);
+        return savedSubscribe.getId();
+    }
+
+    private SyndFeed fetchFeeds(final String requestUrl) {
+        try {
+            return new SyndFeedInput().build(new XmlReader(new URL(requestUrl)));
+        } catch (Exception e) {
+            throw new InvalidRssUrlException(e);
+        }
+    }
+
+    private Rss buildRss(final SyndFeed feedInfo, final String rssUrl) {
+        final var image = feedInfo.getImage();
+        final var icon = feedInfo.getIcon();
+        var iconUrl = "";
+
+        if (Objects.nonNull(image) && StringUtils.hasText(image.getUrl())) {
+            iconUrl = image.getUrl();
+        }
+
+        if (Objects.nonNull(icon) && StringUtils.hasText(icon.getUrl())) {
+            iconUrl = icon.getUrl();
+        }
+
+        final var rss = Rss.builder()
+                .title(feedInfo.getTitle())
+                .rssUrl(rssUrl)
+                .link(feedInfo.getLink())
+                .iconUrl(iconUrl)
+                .build();
+        return rss;
+    }
+
+    private List<Feed> convertFeed(final SyndFeed feedInfo, final Rss savedRss) {
+        final var feeds = feedInfo.getEntries()
+                .stream()
+                .map(newFeed -> createFeed(savedRss, newFeed))
+                .collect(Collectors.toList());
+        return feeds;
+    }
+
+    private Feed createFeed(final Rss rss, final SyndEntry newFeed) {
+        final var feed = Feed.builder()
+                .title(newFeed.getTitle())
+                .link(newFeed.getLink())
+                .description(findDescription(newFeed))
+                .updateDate(findDate(newFeed))
+                .rss(rss)
+                .build();
+        return feed;
+    }
+
+    private String findDescription(final SyndEntry newFeed) {
+        final var description = newFeed.getDescription();
+        if (Objects.nonNull(description) && StringUtils.hasText(description.getValue())) {
+            final String descriptionResult = description.getValue().replaceAll("<[^>]+>", "").strip();
+            int length = descriptionResult.length();
+            if (length > 500) {
+                length = 500;
+            }
+            return descriptionResult.substring(0, length);
+        }
+
+        if (Objects.isNull(newFeed.getContents())) {
+            return "";
+        }
+
+        final var contents = newFeed.getContents().get(0).getValue().replaceAll("<[^>]+>", "").strip();
+        byte[] contentsBytes = contents.getBytes(StandardCharsets.UTF_8);
+        int length = contentsBytes.length;
+        if (length > 500) {
+            length = 500;
+        }
+        return new String(contentsBytes, 0, length);
+    }
+
+    private Date findDate(final SyndEntry newFeed) {
+        var updatedDate = newFeed.getPublishedDate();
+
+        if (Objects.isNull(updatedDate)) {
+            updatedDate = newFeed.getUpdatedDate();
+        }
+        if (Objects.isNull(updatedDate)) {
+            updatedDate = new Date();
+        }
+
+        return updatedDate;
     }
 }

--- a/backend/src/main/java/com/rssmanager/rss/service/RomeFeedFetchService.java
+++ b/backend/src/main/java/com/rssmanager/rss/service/RomeFeedFetchService.java
@@ -88,7 +88,6 @@ public class RomeFeedFetchService implements FeedFetchService {
                 .link(rssInfo.getLink())
                 .iconUrl(rssInfo.getIcon().getUrl())
                 .rssUrl(rssUrl)
-                .recommended(false)
                 .build();
     }
 }

--- a/backend/src/main/java/com/rssmanager/rss/service/SubscribeService.java
+++ b/backend/src/main/java/com/rssmanager/rss/service/SubscribeService.java
@@ -1,0 +1,9 @@
+package com.rssmanager.rss.service;
+
+import com.rssmanager.member.domain.Member;
+import com.rssmanager.rss.controller.dto.SubscribeRequest;
+
+public interface SubscribeService {
+
+    Long subscribe(Member member, SubscribeRequest subscribeRequest);
+}

--- a/backend/src/main/java/com/rssmanager/rss/service/SubscribeService.java
+++ b/backend/src/main/java/com/rssmanager/rss/service/SubscribeService.java
@@ -1,9 +1,13 @@
 package com.rssmanager.rss.service;
 
 import com.rssmanager.member.domain.Member;
+import com.rssmanager.rss.controller.dto.FeedResponses;
 import com.rssmanager.rss.controller.dto.SubscribeRequest;
+import org.springframework.data.domain.Pageable;
 
 public interface SubscribeService {
 
     Long subscribe(Member member, SubscribeRequest subscribeRequest);
+
+    FeedResponses findSubscribedFeeds(Member member, Pageable pageable);
 }

--- a/backend/src/test/java/com/rssmanager/documentation/DocumentationTest.java
+++ b/backend/src/test/java/com/rssmanager/documentation/DocumentationTest.java
@@ -8,6 +8,7 @@ import com.rssmanager.member.service.MemberService;
 import com.rssmanager.rss.service.BookmarkService;
 import com.rssmanager.rss.service.FeedService;
 import com.rssmanager.rss.service.RssService;
+import com.rssmanager.rss.service.SubscribeService;
 import com.rssmanager.util.SessionManager;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
 import io.restassured.module.mockmvc.specification.MockMvcRequestSpecification;
@@ -36,6 +37,8 @@ public class DocumentationTest {
     protected SessionManager sessionManager;
     @MockBean
     protected BookmarkService bookmarkService;
+    @MockBean
+    protected SubscribeService subscribeService;
     protected MockMvcRequestSpecification docsGiven;
 
     @BeforeEach

--- a/frontend/src/components/SubscribedFeeds.js
+++ b/frontend/src/components/SubscribedFeeds.js
@@ -1,0 +1,78 @@
+import {useEffect, useState} from "react";
+import axios from "axios";
+import LoadingSpinner from "../views/LoadingSpinner";
+import Feed from "./Feed";
+
+export default function SubscribedFeeds(props) {
+    const [feeds, setFeeds] = useState([]);
+    let pageNumber = 0;
+    let loading = false;
+    let hasNext = true;
+    const [init, setInit] = useState(true);
+
+    const loadMoreFeeds = (() => {
+        axios.get(`${process.env.REACT_APP_API_HOST}/api/subscribes?page=${pageNumber}`, {withCredentials: true})
+            .then(({data}) => {
+                const newFeeds = [];
+                data.feedResponses.forEach((feed) => newFeeds.push(feed));
+                setFeeds(presentFeeds => [...presentFeeds, ...newFeeds]);
+                pageNumber = data.nextPageable.pageNumber;
+                hasNext = data.hasNext;
+                loading = false;
+                setInit(false);
+
+                if (!hasNext) {
+                    setTimeout(() => {
+                        const aa = document.querySelectorAll('.MuiCard-root')
+                        const target = aa[aa.length - 1]
+                        console.log(target)
+                        target.style.marginBottom = '100px';
+                    }, 100)
+                }
+            })
+            .catch(error => {
+                console.log(error);
+                loading = false;
+            })
+    });
+
+    const handleScroll = (event) => {
+        if (loading || !hasNext) {
+            return;
+        }
+
+        if (window.innerHeight + event.target.documentElement.scrollTop + 1 >=
+            event.target.documentElement.scrollHeight
+        ) {
+            loading = true;
+            loadMoreFeeds();
+        }
+    }
+
+    useEffect(() => {
+        loadMoreFeeds();
+        window.addEventListener('scroll', (event) => handleScroll(event))
+    }, []);
+
+    return (
+        <>
+            {
+                init ? <LoadingSpinner/>
+                    : feeds.map(feed =>
+                        <Feed
+                            key={feed.id}
+                            id={feed.id}
+                            title={feed.title}
+                            link={feed.link}
+                            description={feed.description}
+                            subscribed={feed.subscribed}
+                            updateDate={feed.updateDate}
+                            rssTitle={feed.rss.title}
+                            iconUrl={feed.rss.iconUrl}
+                            bookmarked={feed.bookmarked}
+                        ></Feed>
+                    )
+            }
+        </>
+    );
+}

--- a/frontend/src/views/Subscribed.js
+++ b/frontend/src/views/Subscribed.js
@@ -1,11 +1,66 @@
 import DefaultFeeds from "./DefaultFeeds";
 import BottomNavBar from "../components/BottomNavBar";
+import AddIcon from '@mui/icons-material/Add';
+import {Box, Button, Fab, Modal, TextField, Typography} from "@mui/material";
+import {useState} from "react";
 
 export default function Subscribed(props) {
+    const [open, setOpen] = useState(false);
+    const handleOpen = () => setOpen(true);
+    const handleClose = () => setOpen(false);
+    const httpRegex = '^(https|http):\\/\\/[^\\s$.?#].[^\\s]*$';
+
+    const handleSubscribe = (e) => {
+
+        if (input.length === 0) {
+            return;
+        }
+
+        // axios.post(`${process.env.REACT_APP_API_HOST}/api/subscribes`,
+        //     {url: input}, {withCredentials: true})
+        //     .then(({data}) => {
+        //         console.log(data);
+        //
+        //         location.reload();
+        //     });
+    }
+
+    const style = {
+        position: 'absolute',
+        top: '50%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)',
+        width: 400,
+        bgcolor: 'background.paper',
+        border: '2px solid #000',
+        boxShadow: 24,
+        p: 4,
+    };
+
     return (
         <div className="App">
             <header className="App-header">
+                <Fab size='small' color="primary" aria-label="add" style={{position: 'fixed', top: '85vh'}}>
+                    <AddIcon onClick={handleOpen}/>
+                </Fab>
                 <DefaultFeeds fetchOption={props.fetchOption}/>
+
+                <Modal
+                    open={open}
+                    onClose={handleClose}
+                    aria-labelledby="modal-modal-title"
+                    aria-describedby="modal-modal-description"
+                >
+                    <Box sx={style}>
+                        <Typography id="modal-modal-title" variant="h6" component="h2" style={{marginBottom: 30}}>
+                            구독할 RSS 주소를 입력해주세요
+                        </Typography>
+                        <TextField id="outlined-basic" label="RSS 주소 입력" variant="outlined" style={{width: "100%"}}/>
+                        <div style={{display: 'flex', flexDirection: 'row-reverse'}}>
+                            <Button onClick={handleSubscribe} style={{marginTop: 20}} variant="contained">Add</Button>
+                        </div>
+                    </Box>
+                </Modal>
             </header>
             <footer className="App-footer">
                 <BottomNavBar loginStatus={props.loginStatus} userInfo={props.userInfo} navIndex={props.navIndex}/>

--- a/frontend/src/views/Subscribed.js
+++ b/frontend/src/views/Subscribed.js
@@ -1,28 +1,31 @@
-import DefaultFeeds from "./DefaultFeeds";
 import BottomNavBar from "../components/BottomNavBar";
 import AddIcon from '@mui/icons-material/Add';
-import {Box, Button, Fab, Modal, TextField, Typography} from "@mui/material";
+import {Alert, Box, Button, Fab, Modal, Snackbar, TextField, Typography} from "@mui/material";
 import {useState} from "react";
+import axios from "axios";
+import SubscribedFeeds from "../components/SubscribedFeeds";
 
 export default function Subscribed(props) {
     const [open, setOpen] = useState(false);
     const handleOpen = () => setOpen(true);
     const handleClose = () => setOpen(false);
-    const httpRegex = '^(https|http):\\/\\/[^\\s$.?#].[^\\s]*$';
+    const [openSuccess, setOpenSuccess] = useState(false);
+    const [openError, setOpenError] = useState(false);
+
 
     const handleSubscribe = (e) => {
-
+        const input = document.getElementById('outlined-basic').value;
         if (input.length === 0) {
             return;
         }
 
-        // axios.post(`${process.env.REACT_APP_API_HOST}/api/subscribes`,
-        //     {url: input}, {withCredentials: true})
-        //     .then(({data}) => {
-        //         console.log(data);
-        //
-        //         location.reload();
-        //     });
+        axios.post(`${process.env.REACT_APP_API_HOST}/api/subscribes`,
+            {url: input}, {withCredentials: true})
+            .then(({data}) => {
+                handleClose()
+                setOpenSuccess(true)
+                setTimeout(() => location.reload(), 500)
+            }).catch(error => setOpenError(true));
     }
 
     const style = {
@@ -43,8 +46,20 @@ export default function Subscribed(props) {
                 <Fab size='small' color="primary" aria-label="add" style={{position: 'fixed', top: '85vh'}}>
                     <AddIcon onClick={handleOpen}/>
                 </Fab>
-                <DefaultFeeds fetchOption={props.fetchOption}/>
-
+                <SubscribedFeeds/>
+                <Snackbar anchorOrigin={{vertical: 'top', horizontal: 'center'}} open={openSuccess}
+                          autoHideDuration={800}
+                          onClose={() => setOpen(false)}>
+                    <Alert onClose={() => setOpenSuccess(false)} severity={'success'} sx={{width: '100%'}}>
+                        요청하신 RSS를 구독했어요 😃
+                    </Alert>
+                </Snackbar>
+                <Snackbar anchorOrigin={{vertical: 'top', horizontal: 'center'}} open={openError} autoHideDuration={800}
+                          onClose={() => setOpen(false)}>
+                    <Alert onClose={() => setOpenError(false)} severity={'error'} sx={{width: '100%'}}>
+                        요청에 실패했어요.. 다른 주소로 시도해볼까요? 😅
+                    </Alert>
+                </Snackbar>
                 <Modal
                     open={open}
                     onClose={handleClose}


### PR DESCRIPTION
## 요약

- RSS 주소를 입력해서 구독할 수 있는 기능 구현

<br><br>

## 작업 내용

- FE
  - Subscribed 화면 내 구독을 위한 + 버튼 추가
  - + 눌러 나오는 모달 팝업에서 주소를 입력 후 ADD 누르면 구독처리 후 리프레시
- BE
  - 신규 RSS일 경우
    - RSS 유효성 검증 후 Rss 엔티티 저장
    - 신규 RSS 내 최근 Feed 엔티티들 DB에 저장
    - 사용자 구독 정보 Subscribe 엔티티 저장
  - 등록된 적 있는 RSS일 경우
    - 요청한 사용자가 이미 구독중이면 find해서 응답
    - 요청한 사용자가 구독중이 아니었다면 Subscribe 엔티티 저장 후 응답
  - 유효하지 않은 RSS일 경우
    - 예외 응답

- QueryDSL 도입

<br><br>

## 참고 사항

- 구독 관리 화면을 별도로 만들어야 사용 편의성을 증대시킬 수 있다.
- 현재 구독 해제 기능이 없는 상태다
- 동기적으로 block하여 AJAX, 파싱, DB 저장, 조회, DB 저장 등 많은 작업을 수행하지만, 체감 시간이 생각보다 짧다

<br><br>

## 관련 이슈

- Close #15 

<br><br>
