### PR TITLE
fix: 기본 피드 채널에서 추천 필터링이 동작하지 않는 이슈 수정

### DIFF
--- a/backend/src/main/java/com/rssmanager/rss/service/JpaFeedService.java
+++ b/backend/src/main/java/com/rssmanager/rss/service/JpaFeedService.java
@@ -1,14 +1,17 @@
 package com.rssmanager.rss.service;
 
+import static com.rssmanager.rss.domain.QFeed.feed;
+import static com.rssmanager.rss.domain.QRss.rss;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.rssmanager.rss.controller.dto.FeedResponse;
 import com.rssmanager.rss.controller.dto.FeedResponses;
 import com.rssmanager.rss.domain.Feed;
 import com.rssmanager.rss.repository.FeedRepository;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,28 +19,54 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class JpaFeedService implements FeedService {
     private final FeedRepository feedRepository;
+    private final JPAQueryFactory jpaQueryFactory;
 
-    public JpaFeedService(final FeedRepository feedRepository) {
+    public JpaFeedService(final FeedRepository feedRepository, final JPAQueryFactory jpaQueryFactory) {
         this.feedRepository = feedRepository;
+        this.jpaQueryFactory = jpaQueryFactory;
     }
 
     @Override
     public FeedResponses findFeeds(final Pageable pageable) {
-        final var sort = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
-                Sort.by("updateDate").descending());
+        final var feeds = findRecommendedFeeds(pageable);
 
-        final var feeds = feedRepository.findAll(sort);
-
-        final var feedResponse = feeds.getContent()
-                .stream()
-                .map(FeedResponse::from)
-                .collect(Collectors.toList());
+        final var feedResponses = convertToResponse(pageable, feeds);
+        final var hasNext = feeds.size() > pageable.getPageSize();
+        final var nextPageable = createNextPageable(pageable, hasNext);
 
         return FeedResponses.builder()
-                .feedResponses(feedResponse)
-                .hasNext(feeds.hasNext())
-                .nextPageable(feeds.nextPageable())
+                .feedResponses(feedResponses)
+                .hasNext(hasNext)
+                .nextPageable(nextPageable)
                 .build();
+    }
+
+    private List<Feed> findRecommendedFeeds(final Pageable pageable) {
+        return jpaQueryFactory.selectFrom(feed)
+                .leftJoin(feed.rss, rss)
+                .fetchJoin()
+                .where(rss.recommended.isTrue())
+                .orderBy(feed.updateDate.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+    }
+
+    private List<FeedResponse> convertToResponse(final Pageable pageable, final List<Feed> feeds) {
+        return feeds.stream()
+                .limit(pageable.getPageSize())
+                .map(FeedResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    private Pageable createNextPageable(final Pageable pageable, final boolean hasNext) {
+        var pageNumber = pageable.getPageNumber();
+
+        if (hasNext) {
+            pageNumber++;
+        }
+
+        return pageable.withPage(pageNumber);
     }
 
     @Override


### PR DESCRIPTION
## 요약

- 기본 피드 채널 오류 수정

<br><br>

## 작업 내용

- 피드 조회, 구독 피드 조회 API 메서드 리팩터링
- 기본 피드 채널에 추천 여부 필터링 적용

<br><br>

## 관련 이슈

- Close #28 

<br><br>
