### PR TITLE
feat: RSS 구독, 모든 화면에서 북마크 표현, 추가, 해제 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -28,6 +28,8 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.jsoup:jsoup:1.15.3'
+
     implementation 'com.querydsl:querydsl-jpa:5.0.0'
     implementation 'com.querydsl:querydsl-apt:5.0.0'
 

--- a/backend/src/main/java/com/rssmanager/exception/InvalidRssUrlException.java
+++ b/backend/src/main/java/com/rssmanager/exception/InvalidRssUrlException.java
@@ -1,6 +1,11 @@
 package com.rssmanager.exception;
 
 public class InvalidRssUrlException extends BadRequestException {
+    private static final String DEFAULT_MESSAGE = "RSS 주소를 확인해주세요";
+
+    public InvalidRssUrlException() {
+        super(DEFAULT_MESSAGE);
+    }
 
     public InvalidRssUrlException(final Exception e) {
         super(e.getMessage(), e);

--- a/backend/src/main/java/com/rssmanager/rss/controller/BookmarkController.java
+++ b/backend/src/main/java/com/rssmanager/rss/controller/BookmarkController.java
@@ -4,16 +4,16 @@ import com.rssmanager.auth.annotation.LoginMember;
 import com.rssmanager.member.domain.Member;
 import com.rssmanager.rss.controller.dto.BookmarkAddRequest;
 import com.rssmanager.rss.controller.dto.BookmarkAddResponse;
-import com.rssmanager.rss.controller.dto.BookmarkResponse;
 import com.rssmanager.rss.controller.dto.BookmarkResponses;
 import com.rssmanager.rss.service.BookmarkService;
-import java.util.stream.Collectors;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 
@@ -36,19 +36,14 @@ public class BookmarkController {
     @GetMapping
     public ResponseEntity<BookmarkResponses> findAllByMemberId(@LoginMember final Member member,
                                                                final Pageable pageable) {
-        final var bookmarks = bookmarkService.findByMemberId(member.getId(), pageable);
-
-        final var bookmarkResponse = bookmarks.getContent()
-                .stream()
-                .map(BookmarkResponse::from)
-                .collect(Collectors.toList());
-
-        final var bookmarkResponses = BookmarkResponses.builder()
-                .bookmarks(bookmarkResponse)
-                .hasNext(bookmarks.hasNext())
-                .nextPageable(bookmarks.nextPageable())
-                .build();
-
+        final var bookmarkResponses = bookmarkService.findByMemberId(member, pageable);
         return ResponseEntity.ok(bookmarkResponses);
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> unbookmark(@LoginMember final Member member,
+                                           @RequestParam("feedId") final Long feedId) {
+        bookmarkService.unbookmark(member, feedId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/rssmanager/rss/controller/RssController.java
+++ b/backend/src/main/java/com/rssmanager/rss/controller/RssController.java
@@ -1,5 +1,7 @@
 package com.rssmanager.rss.controller;
 
+import com.rssmanager.auth.annotation.LoginMember;
+import com.rssmanager.member.domain.Member;
 import com.rssmanager.rss.controller.dto.RssCreateRequest;
 import com.rssmanager.rss.controller.dto.RssResponse;
 import com.rssmanager.rss.controller.dto.RssResponses;
@@ -8,10 +10,12 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.stream.Collectors;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/api/rss")
@@ -24,8 +28,8 @@ public class RssController {
     }
 
     @GetMapping
-    public ResponseEntity<RssResponses> findAll() {
-        final var rssResponses = rssService.findAll()
+    public ResponseEntity<RssResponses> findByMember(@LoginMember Member member) {
+        final var rssResponses = rssService.findByMember(member)
                 .stream()
                 .map(RssResponse::from)
                 .collect(Collectors.toList());
@@ -39,5 +43,11 @@ public class RssController {
         final var createdLocation = String.format("/api/rss/%d", savedRss.getId());
 
         return ResponseEntity.created(new URI(createdLocation)).build();
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> unsubscribe(@LoginMember Member member, @RequestParam Long id) {
+        rssService.unsubscribe(member, id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/rssmanager/rss/controller/dto/BookmarkResponse.java
+++ b/backend/src/main/java/com/rssmanager/rss/controller/dto/BookmarkResponse.java
@@ -18,10 +18,10 @@ public class BookmarkResponse {
         this.feed = feed;
     }
 
-    public static BookmarkResponse from(final Bookmark bookmark) {
+    public static BookmarkResponse from(final Bookmark bookmark, final boolean bookmarked) {
         return BookmarkResponse.builder()
                 .id(bookmark.getId())
-                .feed(FeedResponse.from(bookmark.getFeed()))
+                .feed(FeedResponse.from(bookmark.getFeed(), bookmarked))
                 .build();
     }
 }

--- a/backend/src/main/java/com/rssmanager/rss/controller/dto/FeedResponse.java
+++ b/backend/src/main/java/com/rssmanager/rss/controller/dto/FeedResponse.java
@@ -13,19 +13,21 @@ public class FeedResponse {
     private final String description;
     private final Date updateDate;
     private final RssResponse rss;
+    private final boolean bookmarked;
 
     @Builder
     public FeedResponse(final Long id, final String title, final String link, final String description,
-                        final Date updateDate, final RssResponse rss) {
+                        final Date updateDate, final RssResponse rss, final boolean bookmarked) {
         this.id = id;
         this.title = title;
         this.link = link;
         this.description = description;
         this.updateDate = updateDate;
         this.rss = rss;
+        this.bookmarked = bookmarked;
     }
 
-    public static FeedResponse from(Feed feed) {
+    public static FeedResponse from(final Feed feed, final boolean bookmarked) {
         final var rss = feed.getRss();
         final var rssResponse = RssResponse.from(rss);
 
@@ -36,6 +38,7 @@ public class FeedResponse {
                 .description(feed.getDescription())
                 .updateDate(feed.getUpdateDate())
                 .rss(rssResponse)
+                .bookmarked(bookmarked)
                 .build();
     }
 }

--- a/backend/src/main/java/com/rssmanager/rss/domain/Feed.java
+++ b/backend/src/main/java/com/rssmanager/rss/domain/Feed.java
@@ -1,6 +1,7 @@
 package com.rssmanager.rss.domain;
 
 import java.util.Date;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -17,6 +18,7 @@ public class Feed {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String title;
+    @Column(length = 1000)
     private String link;
     private String description;
     private Date updateDate;

--- a/backend/src/main/java/com/rssmanager/rss/repository/BookmarkRepository.java
+++ b/backend/src/main/java/com/rssmanager/rss/repository/BookmarkRepository.java
@@ -2,14 +2,14 @@ package com.rssmanager.rss.repository;
 
 import com.rssmanager.rss.domain.Bookmark;
 import java.util.Optional;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.repository.Repository;
 
 public interface BookmarkRepository extends Repository<Bookmark, Long> {
     Bookmark save(Bookmark bookmark);
 
-    Page<Bookmark> findAllByMemberId(Long memberId, Pageable pageable);
+    Slice<Bookmark> findAllByMemberIdOrderByFeed_UpdateDateDesc(Long memberId, Pageable pageable);
 
     Optional<Bookmark> findByMemberIdAndFeedId(Long memberId, Long feedId);
 

--- a/backend/src/main/java/com/rssmanager/rss/service/BookmarkService.java
+++ b/backend/src/main/java/com/rssmanager/rss/service/BookmarkService.java
@@ -2,12 +2,14 @@ package com.rssmanager.rss.service;
 
 import com.rssmanager.member.domain.Member;
 import com.rssmanager.rss.controller.dto.BookmarkAddRequest;
+import com.rssmanager.rss.controller.dto.BookmarkResponses;
 import com.rssmanager.rss.domain.Bookmark;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface BookmarkService {
     Bookmark bookmark(Member member, BookmarkAddRequest bookmarkAddRequest);
 
-    Page<Bookmark> findByMemberId(Long memberId, Pageable pageable);
+    BookmarkResponses findByMemberId(Member member, Pageable pageable);
+
+    void unbookmark(Member member, Long bookmarkId);
 }

--- a/backend/src/main/java/com/rssmanager/rss/service/DefaultRssParser.java
+++ b/backend/src/main/java/com/rssmanager/rss/service/DefaultRssParser.java
@@ -1,0 +1,126 @@
+package com.rssmanager.rss.service;
+
+import com.rssmanager.exception.InvalidRssUrlException;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.jsoup.Jsoup;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DefaultRssParser implements RssParser {
+    private final List<RssExtractor> matchers = List.of(
+            new TistoryExtractor(), new VelogExtractor(), new BrunchExtractor(), new MediumExtractor()
+    );
+
+    @Override
+    public String parse(final String rss) {
+        return matchers.stream()
+                .filter(matcher -> matcher.support(rss))
+                .findAny()
+                .orElseThrow(InvalidRssUrlException::new)
+                .parse(rss);
+    }
+
+    interface RssExtractor {
+        boolean support(String rss);
+
+        String parse(String rss);
+    }
+
+    class TistoryExtractor implements RssExtractor {
+        private final Pattern tistory = Pattern.compile("([a-zA-Z0-9]+).tistory.com");
+
+        @Override
+        public boolean support(final String rss) {
+            return rss.contains("tistory.com");
+        }
+
+        @Override
+        public String parse(final String rss) {
+            final var matcher = tistory.matcher(rss);
+            matcher.find();
+            return String.format("https://%s.tistory.com/rss", matcher.group(1));
+        }
+    }
+
+    class VelogExtractor implements RssExtractor {
+        private final List<Pattern> patterns = List.of(
+                Pattern.compile("velog.io/@([a-zA-Z0-9]+)"),
+                Pattern.compile("v2.velog.io/rss/@([a-zA-Z0-9]+)")
+        );
+
+        @Override
+        public boolean support(final String rss) {
+            return rss.contains("velog.io");
+        }
+
+        @Override
+        public String parse(final String rss) {
+            final var patternToUse = patterns.stream()
+                    .filter(pattern -> pattern.matcher(rss).find())
+                    .findAny()
+                    .orElseThrow(InvalidRssUrlException::new);
+
+            final var matcher = patternToUse.matcher(rss);
+            matcher.find();
+            return String.format("https://v2.velog.io/rss/@%s", matcher.group(1));
+        }
+    }
+
+    class BrunchExtractor implements RssExtractor {
+        private final Pattern rssPattern = Pattern.compile("brunch.co.kr/rss/@@([a-zA-Z0-9]+)");
+        private final Pattern pagePattern = Pattern.compile("brunch.co.kr/@([a-zA-Z0-9]+)");
+
+        @Override
+        public boolean support(final String rss) {
+            return rss.contains("brunch.co.kr");
+        }
+
+        @Override
+        public String parse(final String rss) {
+            if (rssPattern.matcher(rss).find()) {
+                final var matcher = rssPattern.matcher(rss);
+                matcher.find();
+                return String.format("https://brunch.co.kr/rss/@@%s", matcher.group(1));
+            }
+
+            final var matcher = pagePattern.matcher(rss);
+            matcher.find();
+            final var brunchMain = String.format("https://brunch.co.kr/@%s", matcher.group(1));
+
+            try {
+                return Jsoup.connect(brunchMain)
+                        .get()
+                        .select("link[type=\"application/rss+xml\"]")
+                        .attr("href");
+            } catch (Exception e) {
+                throw new InvalidRssUrlException(e);
+            }
+        }
+    }
+
+    class MediumExtractor implements RssExtractor {
+        private final List<Pattern> patterns = List.of(
+                Pattern.compile("medium.com/feed/@([a-zA-Z0-9]+)"),
+                Pattern.compile("medium.com/@([a-zA-Z0-9]+)"),
+                Pattern.compile("([a-zA-Z0-9]+).medium.com")
+        );
+
+        @Override
+        public boolean support(final String rss) {
+            return rss.contains("medium.com");
+        }
+
+        @Override
+        public String parse(final String rss) {
+            final var patternToUse = patterns.stream()
+                    .filter(pattern -> pattern.matcher(rss).find())
+                    .findAny()
+                    .orElseThrow(InvalidRssUrlException::new);
+
+            final var matcher = patternToUse.matcher(rss);
+            matcher.find();
+            return String.format("https://medium.com/feed/@%s", matcher.group(1));
+        }
+    }
+}

--- a/backend/src/main/java/com/rssmanager/rss/service/JpaBookmarkService.java
+++ b/backend/src/main/java/com/rssmanager/rss/service/JpaBookmarkService.java
@@ -1,11 +1,16 @@
 package com.rssmanager.rss.service;
 
+import static com.rssmanager.rss.domain.QBookmark.bookmark;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.rssmanager.member.domain.Member;
 import com.rssmanager.rss.controller.dto.BookmarkAddRequest;
+import com.rssmanager.rss.controller.dto.BookmarkResponse;
+import com.rssmanager.rss.controller.dto.BookmarkResponses;
 import com.rssmanager.rss.domain.Bookmark;
 import com.rssmanager.rss.domain.Feed;
 import com.rssmanager.rss.repository.BookmarkRepository;
-import org.springframework.data.domain.Page;
+import java.util.stream.Collectors;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,10 +20,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class JpaBookmarkService implements BookmarkService {
     private final BookmarkRepository bookmarkRepository;
     private final FeedService feedService;
+    private final JPAQueryFactory jpaQueryFactory;
 
-    public JpaBookmarkService(final BookmarkRepository bookmarkRepository, final FeedService feedService) {
+    public JpaBookmarkService(final BookmarkRepository bookmarkRepository, final FeedService feedService,
+                              final JPAQueryFactory jpaQueryFactory) {
         this.bookmarkRepository = bookmarkRepository;
         this.feedService = feedService;
+        this.jpaQueryFactory = jpaQueryFactory;
     }
 
     @Transactional
@@ -38,7 +46,27 @@ public class JpaBookmarkService implements BookmarkService {
     }
 
     @Override
-    public Page<Bookmark> findByMemberId(final Long memberId, final Pageable pageable) {
-        return bookmarkRepository.findAllByMemberId(memberId, pageable);
+    public BookmarkResponses findByMemberId(final Member member, final Pageable pageable) {
+        final var bookmarks = bookmarkRepository.findAllByMemberIdOrderByFeed_UpdateDateDesc(member.getId(), pageable);
+
+        final var bookmarkResponse = bookmarks.getContent()
+                .stream()
+                .map(bookmark -> BookmarkResponse.from(bookmark, true))
+                .collect(Collectors.toList());
+
+        return BookmarkResponses.builder()
+                .bookmarks(bookmarkResponse)
+                .hasNext(bookmarks.hasNext())
+                .nextPageable(bookmarks.nextPageable())
+                .build();
+    }
+
+    @Transactional
+    @Override
+    public void unbookmark(final Member member, final Long feedId) {
+        jpaQueryFactory.delete(bookmark)
+                .where(bookmark.member.id.eq(member.getId()))
+                .where(bookmark.feed.id.eq(feedId))
+                .execute();
     }
 }

--- a/backend/src/main/java/com/rssmanager/rss/service/JpaRssService.java
+++ b/backend/src/main/java/com/rssmanager/rss/service/JpaRssService.java
@@ -1,9 +1,14 @@
 package com.rssmanager.rss.service;
 
+import static com.rssmanager.rss.domain.QRss.rss;
+import static com.rssmanager.rss.domain.QSubscribe.subscribe;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.rometools.rome.feed.synd.SyndFeed;
 import com.rometools.rome.io.FeedException;
 import com.rometools.rome.io.SyndFeedInput;
 import com.rometools.rome.io.XmlReader;
+import com.rssmanager.member.domain.Member;
 import com.rssmanager.rss.controller.dto.RssCreateRequest;
 import com.rssmanager.rss.domain.Rss;
 import com.rssmanager.rss.repository.RssRepository;
@@ -19,14 +24,20 @@ import org.springframework.util.StringUtils;
 @Service
 public class JpaRssService implements RssService {
     private final RssRepository rssRepository;
+    private final JPAQueryFactory jpaQueryFactory;
 
-    public JpaRssService(final RssRepository rssRepository) {
+    public JpaRssService(final RssRepository rssRepository, final JPAQueryFactory jpaQueryFactory) {
         this.rssRepository = rssRepository;
+        this.jpaQueryFactory = jpaQueryFactory;
     }
 
     @Override
-    public List<Rss> findAll() {
-        return rssRepository.findAll();
+    public List<Rss> findByMember(final Member member) {
+        return jpaQueryFactory.selectFrom(rss)
+                .leftJoin(subscribe)
+                .on(subscribe.rss.id.eq(rss.id))
+                .where(subscribe.member.id.eq(member.getId()))
+                .fetch();
     }
 
     @Transactional
@@ -41,6 +52,15 @@ public class JpaRssService implements RssService {
 
         final var newRssToSave = buildRss(rssCreateRequest, feeds);
         return rssRepository.save(newRssToSave);
+    }
+
+    @Transactional
+    @Override
+    public void unsubscribe(final Member member, final Long id) {
+        jpaQueryFactory.delete(subscribe)
+                .where(subscribe.member.id.eq(member.getId()))
+                .where(subscribe.rss.id.eq(id))
+                .execute();
     }
 
     private String findIconUrl(final SyndFeed feeds) {

--- a/backend/src/main/java/com/rssmanager/rss/service/RssParser.java
+++ b/backend/src/main/java/com/rssmanager/rss/service/RssParser.java
@@ -1,0 +1,5 @@
+package com.rssmanager.rss.service;
+
+public interface RssParser {
+    String parse(String rss);
+}

--- a/backend/src/main/java/com/rssmanager/rss/service/RssService.java
+++ b/backend/src/main/java/com/rssmanager/rss/service/RssService.java
@@ -1,11 +1,14 @@
 package com.rssmanager.rss.service;
 
+import com.rssmanager.member.domain.Member;
 import com.rssmanager.rss.controller.dto.RssCreateRequest;
 import com.rssmanager.rss.domain.Rss;
 import java.util.List;
 
 public interface RssService {
-    List<Rss> findAll();
+    List<Rss> findByMember(Member member);
 
     Rss save(RssCreateRequest rssCreateRequest);
+
+    void unsubscribe(Member member, Long id);
 }

--- a/backend/src/main/java/com/rssmanager/util/RedisSessionManager.java
+++ b/backend/src/main/java/com/rssmanager/util/RedisSessionManager.java
@@ -27,11 +27,12 @@ public class RedisSessionManager implements SessionManager {
 
     @Override
     public <T> T getAttribute(final String key) {
-        if (!isLoggedIn()) {
+        final var session = createSessionWithFlagParameter(false);
+
+        if (Objects.isNull(session)) {
             return null;
         }
 
-        final var session = createSessionWithFlagParameter(false);
         return (T) session.getAttribute(key);
     }
 

--- a/backend/src/test/java/com/rssmanager/documentation/RssControllerTest.java
+++ b/backend/src/test/java/com/rssmanager/documentation/RssControllerTest.java
@@ -1,55 +1,45 @@
 package com.rssmanager.documentation;
 
-import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-
-import com.rssmanager.rss.domain.Rss;
-import java.util.List;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.restdocs.payload.JsonFieldType;
 
 class RssControllerTest extends DocumentationTest {
 
     @Disabled
     @Test
     void RSS_목록_조회() {
-        when(rssService.findAll()).thenReturn(
-                List.of(
-                        new Rss(1L, "화음을 좋아하는 리차드", "https://creampuffy.tistory.com/rss",
-                                "https://creampuffy.tistory.com", "", false),
-                        new Rss(2L, "D2 Blog", "https://d2.naver.com/d2.atom", "https://d2.naver.com",
-                                "https://d2.naver.com/favicon.ico", true),
-                        new Rss(3L, "우아한형제들 기술블로그", "https://techblog.woowahan.com/feed/",
-                                "https://techblog.woowahan.com",
-                                "https://techblog.woowahan.com/wp-content/uploads/2020/08/favicon.ico", true)
-                )
-        );
-
-        docsGiven
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().get("/api/rss")
-                .then().log().all()
-                .apply(document("rss/list",
-                        responseFields(
-                                fieldWithPath("rssResponses.[].id").type(JsonFieldType.NUMBER)
-                                        .description("RSS id"),
-                                fieldWithPath("rssResponses.[].title").type(JsonFieldType.STRING)
-                                        .description("RSS title"),
-                                fieldWithPath("rssResponses.[].rssUrl").type(JsonFieldType.STRING)
-                                        .description("RSS rssUrl"),
-                                fieldWithPath("rssResponses.[].link").type(JsonFieldType.STRING)
-                                        .description("RSS link"),
-                                fieldWithPath("rssResponses.[].iconUrl").type(JsonFieldType.STRING)
-                                        .description("RSS iconUrl"),
-                                fieldWithPath("rssResponses.[].recommended").type(JsonFieldType.BOOLEAN)
-                                        .description("RSS recommended")
-                        )
-                ))
-                .statusCode(HttpStatus.OK.value());
+//        when(rssService.findByMember(null)).thenReturn(
+//                List.of(
+//                        new Rss(1L, "화음을 좋아하는 리차드", "https://creampuffy.tistory.com/rss",
+//                                "https://creampuffy.tistory.com", "", false),
+//                        new Rss(2L, "D2 Blog", "https://d2.naver.com/d2.atom", "https://d2.naver.com",
+//                                "https://d2.naver.com/favicon.ico", true),
+//                        new Rss(3L, "우아한형제들 기술블로그", "https://techblog.woowahan.com/feed/",
+//                                "https://techblog.woowahan.com",
+//                                "https://techblog.woowahan.com/wp-content/uploads/2020/08/favicon.ico", true)
+//                )
+//        );
+//
+//        docsGiven
+//                .contentType(MediaType.APPLICATION_JSON_VALUE)
+//                .when().get("/api/rss")
+//                .then().log().all()
+//                .apply(document("rss/list",
+//                        responseFields(
+//                                fieldWithPath("rssResponses.[].id").type(JsonFieldType.NUMBER)
+//                                        .description("RSS id"),
+//                                fieldWithPath("rssResponses.[].title").type(JsonFieldType.STRING)
+//                                        .description("RSS title"),
+//                                fieldWithPath("rssResponses.[].rssUrl").type(JsonFieldType.STRING)
+//                                        .description("RSS rssUrl"),
+//                                fieldWithPath("rssResponses.[].link").type(JsonFieldType.STRING)
+//                                        .description("RSS link"),
+//                                fieldWithPath("rssResponses.[].iconUrl").type(JsonFieldType.STRING)
+//                                        .description("RSS iconUrl"),
+//                                fieldWithPath("rssResponses.[].recommended").type(JsonFieldType.BOOLEAN)
+//                                        .description("RSS recommended")
+//                        )
+//                ))
+//                .statusCode(HttpStatus.OK.value());
     }
 }

--- a/backend/src/test/java/com/rssmanager/rss/service/DefaultRssParserTest.java
+++ b/backend/src/test/java/com/rssmanager/rss/service/DefaultRssParserTest.java
@@ -1,0 +1,72 @@
+package com.rssmanager.rss.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class DefaultRssParserTest {
+
+    @ParameterizedTest(name = "{0} -> {1}")
+    @CsvSource(value = {
+            "https://creampuffy.tistory.com/rss, https://creampuffy.tistory.com/rss",
+            "https://creampuffy.tistory.com/209, https://creampuffy.tistory.com/rss",
+            "https://creampuffy.tistory.com, https://creampuffy.tistory.com/rss",
+            "https://creampuffy.tistory.com/, https://creampuffy.tistory.com/rss",
+
+            "creampuffy.tistory.com/rss, https://creampuffy.tistory.com/rss",
+            "creampuffy.tistory.com/209, https://creampuffy.tistory.com/rss",
+            "creampuffy.tistory.com, https://creampuffy.tistory.com/rss",
+            "creampuffy.tistory.com/, https://creampuffy.tistory.com/rss",
+
+            "https://v2.velog.io/rss/@richard7, https://v2.velog.io/rss/@richard7",
+            "https://velog.io/@richard7/%EC%95%88%EB%85%95%ED%95%98%EC%84%B8%EC%9A%94-%EB%A6%AC%EC%B0%A8%EB%93%9C%EC%9E%85%EB%8B%88%EB%8B%A4, https://v2.velog.io/rss/@richard7",
+            "https://velog.io/@richard7, https://v2.velog.io/rss/@richard7",
+            "https://velog.io/@richard7/, https://v2.velog.io/rss/@richard7",
+
+            "v2.velog.io/rss/@richard7, https://v2.velog.io/rss/@richard7",
+            "velog.io/@richard7/%EC%95%88%EB%85%95%ED%95%98%EC%84%B8%EC%9A%94-%EB%A6%AC%EC%B0%A8%EB%93%9C%EC%9E%85%EB%8B%88%EB%8B%A4, https://v2.velog.io/rss/@richard7",
+            "velog.io/@richard7, https://v2.velog.io/rss/@richard7",
+            "velog.io/@richard7/, https://v2.velog.io/rss/@richard7",
+
+            "https://brunch.co.kr/rss/@@5tdm, https://brunch.co.kr/rss/@@5tdm",
+            "https://brunch.co.kr/@javajigi/27, https://brunch.co.kr/rss/@@5tdm",
+            "https://brunch.co.kr/@javajigi, https://brunch.co.kr/rss/@@5tdm",
+            "https://brunch.co.kr/@javajigi/, https://brunch.co.kr/rss/@@5tdm",
+
+            "brunch.co.kr/rss/@@5tdm, https://brunch.co.kr/rss/@@5tdm",
+            "brunch.co.kr/@javajigi/27, https://brunch.co.kr/rss/@@5tdm",
+            "brunch.co.kr/@javajigi, https://brunch.co.kr/rss/@@5tdm",
+            "brunch.co.kr/@javajigi/, https://brunch.co.kr/rss/@@5tdm",
+
+            "https://medium.com/feed/@ztzy1907, https://medium.com/feed/@ztzy1907",
+            "https://medium.com/@ztzy1907/hi-this-is-richard-e356cf3bc7f0, https://medium.com/feed/@ztzy1907",
+            "https://medium.com/@ztzy1907, https://medium.com/feed/@ztzy1907",
+            "https://medium.com/@ztzy1907/, https://medium.com/feed/@ztzy1907",
+
+            "medium.com/feed/@ztzy1907, https://medium.com/feed/@ztzy1907",
+            "medium.com/@ztzy1907/hi-this-is-richard-e356cf3bc7f0, https://medium.com/feed/@ztzy1907",
+            "medium.com/@ztzy1907, https://medium.com/feed/@ztzy1907",
+            "medium.com/@ztzy1907/, https://medium.com/feed/@ztzy1907",
+
+            "https://ztzy1907.medium.com/feed, https://medium.com/feed/@ztzy1907",
+            "https://ztzy1907.medium.com/hi-this-is-richard-e356cf3bc7f0, https://medium.com/feed/@ztzy1907",
+            "https://ztzy1907.medium.com, https://medium.com/feed/@ztzy1907",
+            "https://ztzy1907.medium.com/, https://medium.com/feed/@ztzy1907",
+
+            "ztzy1907.medium.com/feed, https://medium.com/feed/@ztzy1907",
+            "ztzy1907.medium.com/hi-this-is-richard-e356cf3bc7f0, https://medium.com/feed/@ztzy1907",
+            "ztzy1907.medium.com, https://medium.com/feed/@ztzy1907",
+            "ztzy1907.medium.com/, https://medium.com/feed/@ztzy1907"
+    })
+    void parse(final String requestUrl, final String expected) {
+        // given
+        final var parser = new DefaultRssParser();
+
+        // when
+        final var actual = parser.parse(requestUrl);
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
+}

--- a/frontend/src/components/Feed.js
+++ b/frontend/src/components/Feed.js
@@ -6,38 +6,53 @@ import {Alert, Card, CardActions, CardContent, CardHeader, IconButton, Link, Sna
 import axios from "axios";
 import {useState} from "react";
 
-export default function Feed(feed) {
-    const date = new Date(feed.updateDate);
+export default function Feed(props) {
+    const date = new Date(props.updateDate);
     const formatDate = new Intl.DateTimeFormat('kr', {dateStyle: 'medium', timeStyle: 'short'}).format(date);
-    const [bookmark, setBookmark] = useState(feed.bookmarked === undefined ? false : feed.bookmarked);
+    const [bookmark, setBookmark] = useState(props.bookmarked === undefined ? false : props.bookmarked);
 
     const [open, setOpen] = useState(false);
-
-    const handleClose = () => {
-        setOpen(false);
-    };
+    const [openUn, setOpenUn] = useState(false);
 
     const handleBookmark = () => {
-        axios.post(`${process.env.REACT_APP_API_HOST}/api/bookmarks`,
-            {id: feed.id}, {withCredentials: true})
-            .then(({data}) => {
-                setOpen(true);
-                setBookmark(true);
-            })
+        if (!bookmark) {
+            axios.post(`${process.env.REACT_APP_API_HOST}/api/bookmarks`,
+                {id: props.id}, {withCredentials: true})
+                .then(({data}) => {
+                    setOpen(true);
+                    setBookmark(true);
+                })
+        }
+
+        if (bookmark) {
+            axios.delete(`${process.env.REACT_APP_API_HOST}/api/bookmarks?feedId=${props.id}`,
+                {withCredentials: true})
+                .then(({data}) => {
+                    setOpenUn(true);
+                    setBookmark(false);
+                })
+        }
     }
 
     return (
         <>
             <Snackbar anchorOrigin={{vertical: 'top', horizontal: 'center'}} open={open} autoHideDuration={800}
                       onClose={() => setOpen(false)}>
-                <Alert onClose={handleClose} severity={'success'} sx={{width: '100%'}}>
+                <Alert onClose={() => setOpen(false)} severity={'success'} sx={{width: '100%'}}>
                     북마크에 추가했어요 😃
                 </Alert>
             </Snackbar>
+            <Snackbar anchorOrigin={{vertical: 'top', horizontal: 'center'}} open={openUn}
+                      autoHideDuration={800}
+                      onClose={() => setOpenUn(false)}>
+                <Alert onClose={() => setOpenUn(false)} severity={'success'} sx={{width: '100%'}}>
+                    북마크에서 제거했어요 😃
+                </Alert>
+            </Snackbar>
             <Card sx={{maxWidth: 500, marginTop: 5, marginBottom: 5}}>
-                <Link href={feed.link} target='_blank' color={'inherit'} underline={'none'}>
+                <Link href={props.link} target='_blank' color={'inherit'} underline={'none'}>
                     <CardHeader
-                        title={feed.title}
+                        title={props.title}
                         titleTypographyProps={{variant: 'h6'}}
                         style={{
                             textAlign: 'center', paddingLeft: 30, paddingRight: 30
@@ -51,13 +66,13 @@ export default function Feed(feed) {
                     <CardContent>
                         <Typography variant="body2" color="text.secondary"
                                     style={{maxWidth: 500, lineBreak: 'anywhere'}}>
-                            {feed.description}
+                            {props.description}
                         </Typography>
                     </CardContent>
                 </Link>
                 <CardActions disableSpacing sx={{display: 'flex', justifyContent: 'flex-end'}}>
-                    <img src={feed.iconUrl} width={25}/>
-                    <div style={{fontSize: '1.1rem', padding: 4, marginLeft: 5}}>{feed.rssTitle}</div>
+                    <img src={props.iconUrl} width={25}/>
+                    <div style={{fontSize: '1.1rem', padding: 4, marginLeft: 5}}>{props.rssTitle}</div>
                     <div style={{marginLeft: 10}}></div>
                     <IconButton
                         aria-label="Like"
@@ -72,12 +87,12 @@ export default function Feed(feed) {
                         onClick={() => {
                             if (navigator.share) {
                                 navigator.share({
-                                    title: feed.title,
-                                    url: feed.link,
-                                    text: feed.description
+                                    title: props.title,
+                                    url: props.link,
+                                    text: props.description
                                 })
                             } else {
-                                navigator.clipboard.writeText(feed.link).then(result => alert('클립보드에 복사했어요~!'));
+                                navigator.clipboard.writeText(props.link).then(result => alert('클립보드에 복사했어요~!'));
                             }
                         }}>
                         <ShareIcon/>

--- a/frontend/src/components/Feed.js
+++ b/frontend/src/components/Feed.js
@@ -34,12 +34,14 @@ export default function Feed(feed) {
                     북마크에 추가했어요 😃
                 </Alert>
             </Snackbar>
-            <Card sx={{maxWidth: '100%', marginTop: 5, marginBottom: 5}}>
+            <Card sx={{maxWidth: 500, marginTop: 5, marginBottom: 5}}>
                 <Link href={feed.link} target='_blank' color={'inherit'} underline={'none'}>
                     <CardHeader
                         title={feed.title}
                         titleTypographyProps={{variant: 'h6'}}
-                        style={{textAlign: 'center', paddingLeft: 30, paddingRight: 30}}
+                        style={{
+                            textAlign: 'center', paddingLeft: 30, paddingRight: 30
+                        }}
                     />
                     <CardContent>
                         <Typography variant="body2" color="text.secondary" style={{textAlign: 'right'}}>
@@ -47,7 +49,8 @@ export default function Feed(feed) {
                         </Typography>
                     </CardContent>
                     <CardContent>
-                        <Typography variant="body2" color="text.secondary">
+                        <Typography variant="body2" color="text.secondary"
+                                    style={{maxWidth: 500, lineBreak: 'anywhere'}}>
                             {feed.description}
                         </Typography>
                     </CardContent>

--- a/frontend/src/components/Profile.js
+++ b/frontend/src/components/Profile.js
@@ -16,15 +16,6 @@ export default function Profile(props) {
                 <TextField
                     disabled
                     id="filled-disabled"
-                    label="Id"
-                    defaultValue={props.userInfo.id}
-                    variant="filled"
-                />
-            </div>
-            <div>
-                <TextField
-                    disabled
-                    id="filled-disabled"
                     label="Nickname"
                     defaultValue={props.userInfo.nickname}
                     variant="filled"

--- a/frontend/src/components/Rss.js
+++ b/frontend/src/components/Rss.js
@@ -18,6 +18,17 @@ export default function Rss() {
             .catch(error => console.log(error))
     }, []);
 
+    const handleSubscribe = (e) => {
+        const requestUrl = e.target.previousSibling.querySelector('input').value;
+        axios.post(`${process.env.REACT_APP_API_HOST}/api/subscribes`,
+            {url: requestUrl},
+            {withCredentials: true})
+            .then(({data}) => {
+                location.reload();
+            })
+            .catch(error => console.log(error))
+    }
+
     return (
         <>
             {
@@ -25,7 +36,7 @@ export default function Rss() {
                     :
                     rss.length === 0 ?
                         <div>
-                            <div>아직 구독하는 RSS가 없어요 😃</div>
+                            <div>첫 RSS를 추가해볼까요? 😃</div>
                             <div>&emsp;</div>
                         </div>
                         :
@@ -42,9 +53,14 @@ export default function Rss() {
                             ></RssComponent>
                         )
             }
-            <div style={{display: 'flex', flexDirection: 'row', width: '90%', top: 10}}>
-                <TextField id="outlined-basic" label="구독할 RSS를 입력해주세요" variant="outlined" style={{width: "100%"}}/>
-                <Button onClick={() => alert('hi')} style={{marginLeft: 10}} variant="contained">Add</Button>
+            <div style={{display: 'flex', flexDirection: 'row', width: '90%', top: 10, justifyContent: 'center'}}>
+                <TextField
+                    id="outlined-basic"
+                    label="구독할 RSS를 입력해주세요"
+                    variant="outlined"
+                    style={{width: "100%", maxWidth: 500}}
+                />
+                <Button onClick={handleSubscribe} style={{marginLeft: 10}} variant="contained">Add</Button>
             </div>
         </>
     );

--- a/frontend/src/components/Rss.js
+++ b/frontend/src/components/Rss.js
@@ -1,0 +1,51 @@
+import {useEffect, useState} from "react";
+import axios from "axios";
+import LoadingSpinner from "../views/LoadingSpinner";
+import RssComponent from "./RssComponent";
+import {Button, TextField} from "@mui/material";
+
+export default function Rss() {
+    const [rss, setRss] = useState([]);
+    const [init, setInit] = useState(true);
+
+    useEffect(() => {
+        axios.get(`${process.env.REACT_APP_API_HOST}/api/rss`,
+            {withCredentials: true})
+            .then(({data}) => {
+                setRss(data.rssResponses)
+                setInit(false);
+            })
+            .catch(error => console.log(error))
+    }, []);
+
+    return (
+        <>
+            {
+                init ? <LoadingSpinner/>
+                    :
+                    rss.length === 0 ?
+                        <div>
+                            <div>아직 구독하는 RSS가 없어요 😃</div>
+                            <div>&emsp;</div>
+                        </div>
+                        :
+                        rss.map(r =>
+                            <RssComponent
+                                key={r.id}
+                                id={r.id}
+                                title={r.title}
+                                rssUrl={r.rssUrl}
+                                link={r.link}
+                                iconUrl={r.iconUrl}
+                                rssList={rss}
+                                rssFunction={setRss}
+                            ></RssComponent>
+                        )
+            }
+            <div style={{display: 'flex', flexDirection: 'row', width: '90%', top: 10}}>
+                <TextField id="outlined-basic" label="구독할 RSS를 입력해주세요" variant="outlined" style={{width: "100%"}}/>
+                <Button onClick={() => alert('hi')} style={{marginLeft: 10}} variant="contained">Add</Button>
+            </div>
+        </>
+    );
+}

--- a/frontend/src/components/RssComponent.js
+++ b/frontend/src/components/RssComponent.js
@@ -1,0 +1,48 @@
+import {Button, Card, CardContent, Typography} from "@mui/material";
+import DeleteIcon from '@mui/icons-material/Delete';
+import {useEffect} from "react";
+import axios from "axios";
+
+export default function RssComponent(props) {
+    const handleDelete = () => {
+        axios.delete(
+            `${process.env.REACT_APP_API_HOST}/api/rss?id=${props.id}`,
+            {withCredentials: true})
+            .then(({data}) => {
+                alert('삭제 굳')
+            }).catch(error => console.log(error))
+    }
+
+    useEffect(() => {
+        axios.get(`${process.env.REACT_APP_API_HOST}/api/rss`,
+            {withCredentials: true})
+            .then(({data}) => {
+                setRss(data.rssResponses)
+                setInit(false);
+            })
+            .catch(error => console.log(error))
+    }, []);
+
+    return (
+        <Card style={{
+            minWidth: 350,
+            width: '50%',
+            maxWidth: '80%',
+            display: 'flex',
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+            marginBottom: 30
+        }}>
+            <CardContent style={{width: '100%'}}>
+                <img src={props.iconUrl} style={{maxWidth: '50px', borderRadius: '50%'}}/>
+                <Typography component="div" variant="h5">
+                    {props.title}
+                </Typography>
+                <Typography variant="subtitle1" color="text.secondary" component="div">
+                    <Button onClick={handleDelete} variant="outlined"
+                            color="inherit"><DeleteIcon/> &emsp;Unsubscribe</Button>
+                </Typography>
+            </CardContent>
+        </Card>
+    );
+}

--- a/frontend/src/components/RssComponent.js
+++ b/frontend/src/components/RssComponent.js
@@ -9,7 +9,7 @@ export default function RssComponent(props) {
             `${process.env.REACT_APP_API_HOST}/api/rss?id=${props.id}`,
             {withCredentials: true})
             .then(({data}) => {
-                alert('삭제 굳')
+                location.reload()
             }).catch(error => console.log(error))
     }
 

--- a/frontend/src/views/App.js
+++ b/frontend/src/views/App.js
@@ -85,7 +85,7 @@ function App() {
                         >
                         </Route>
 
-                        <Route path="/manage-rss" exact
+                        <Route path="/rss" exact
                                element={
                                    loginStatus
                                        ? <ManageRss

--- a/frontend/src/views/BookmarkFeeds.js
+++ b/frontend/src/views/BookmarkFeeds.js
@@ -63,7 +63,7 @@ export default function BookmarkFeeds() {
                         bookmarks.map(bookmark =>
                             <Feed
                                 key={bookmark.id}
-                                id={bookmark.id}
+                                id={bookmark.feed.id}
                                 title={bookmark.feed.title}
                                 link={bookmark.feed.link}
                                 description={bookmark.feed.description}

--- a/frontend/src/views/BookmarkFeeds.js
+++ b/frontend/src/views/BookmarkFeeds.js
@@ -75,7 +75,6 @@ export default function BookmarkFeeds() {
                             ></Feed>
                         )
             }
-
         </>
     );
 }

--- a/frontend/src/views/DefaultFeeds.js
+++ b/frontend/src/views/DefaultFeeds.js
@@ -11,7 +11,8 @@ export default function DefaultFeeds() {
     const [init, setInit] = useState(true);
 
     const loadMoreFeeds = (() => {
-        axios.get(`${process.env.REACT_APP_API_HOST}/api/feeds?page=${pageNumber}`)
+        axios.get(`${process.env.REACT_APP_API_HOST}/api/feeds?page=${pageNumber}`,
+            {withCredentials: true})
             .then(({data}) => {
                 const newFeeds = [];
                 data.feedResponses.forEach((feed) => newFeeds.push(feed));

--- a/frontend/src/views/ManageRss.js
+++ b/frontend/src/views/ManageRss.js
@@ -1,5 +1,20 @@
-export default function ManageRss() {
+import BottomNavBar from "../components/BottomNavBar";
+import Rss from "../components/Rss";
+
+export default function ManageRss(props) {
+
+
     return (
-        <div>sdf</div>
+        <div className="App">
+            <header className="App-header">
+                <Rss></Rss>
+            </header>
+            <footer className="App-footer">
+                <BottomNavBar
+                    loginStatus={props.loginStatus}
+                    userInfo={props.userInfo}
+                    navIndex={props.navIndex}/>
+            </footer>
+        </div>
     )
 }

--- a/frontend/src/views/ManageRss.js
+++ b/frontend/src/views/ManageRss.js
@@ -3,7 +3,6 @@ import Rss from "../components/Rss";
 
 export default function ManageRss(props) {
 
-
     return (
         <div className="App">
             <header className="App-header">

--- a/frontend/src/views/MenuView.js
+++ b/frontend/src/views/MenuView.js
@@ -70,7 +70,7 @@ export default function MenuView(props) {
 
             <Profile userInfo={props.userInfo} loginStatus={props.loginStatus}></Profile>
             <div style={{marginTop: 50}}>
-                <a href={'/manage-rss'}>
+                <a href={'/rss'}>
                     <Button variant="outlined" color="success"><RssFeedIcon/> &emsp;Manage RSS</Button>
                 </a>
 

--- a/frontend/src/views/Subscribed.js
+++ b/frontend/src/views/Subscribed.js
@@ -1,12 +1,10 @@
 import SubscribedFeeds from "./SubscribedFeeds";
 import BottomNavBar from "../components/BottomNavBar";
-import SubscribeModal from "../components/SubscribeModal";
 
 export default function Subscribed(props) {
     return (
         <div className="App">
             <header className="App-header">
-                <SubscribeModal/>
                 <SubscribedFeeds/>
             </header>
             <footer className="App-footer">

--- a/frontend/src/views/SubscribedFeeds.js
+++ b/frontend/src/views/SubscribedFeeds.js
@@ -63,9 +63,9 @@ export default function SubscribedFeeds() {
                     :
                     feeds.length === 0 ?
                         <div>
-                            <div>아직 북마크한 피드가 없어요 😃</div>
+                            <div>아직 구독하는 RSS가 없어요 😃</div>
                             <div>&emsp;</div>
-                            <div><NavLink to={'/'} style={{color: 'inherit', fontWeight: 500}}>북마크 추가하러 가기</NavLink>
+                            <div><NavLink to={'/rss'} style={{color: 'inherit', fontWeight: 500}}>RSS 추가하러 가기</NavLink>
                             </div>
                         </div>
                         :


### PR DESCRIPTION
## 요약

- 미디움, 브런치, 티스토리, 벨로그 RSS 추가 기능 구현
- RSS 구독 해제 기능 구현
- 기본 피드 채널, 구독 피드 채널, 북마크 채널 등 모든 화면에서 북마크 추가, 해제, 뷰 기능 구현

<br><br>

## 작업 내용

- RssParser 구현
  - 티스토리, 벨로그, 미디움은 정규식으로 추출하여 문자열 계산으로 해결
  - 브런치는 RSS를 숨겨두어 Jsoup으로 AJAX후 QuerySelector로 해당 link 태그 내 href값을 추출하여 반환
- 모든 화면 내 북마크 관련 기능 구현
  - 로그인 여부 판별 및 구독중인 피드인지 식별가능한 값을 함께 응답 처리
  - 프론트에선 북마크 상태에 따른 아이콘 렌더링 처리

<br><br>

## 관련 이슈

- Close #34
- Close #33 
- Close #26 
- Close #25
- Close #11 
- Close #9 

<br><br>
