### PR TITLE
feat: 더 불러올 피드가 없을 경우 하단 표기

### DIFF
--- a/frontend/src/views/BookmarkFeeds.js
+++ b/frontend/src/views/BookmarkFeeds.js
@@ -5,7 +5,7 @@ import LoadingSpinner from "./LoadingSpinner";
 import Feed from "../components/Feed";
 
 export default function BookmarkFeeds() {
-    const [bookmarks, setBookmarks] = useState([]);
+    const [bookmarks, setBookmarks] = useState(new Set());
     let pageNumber = 0;
     let loading = false;
     let hasNext = true;
@@ -15,13 +15,28 @@ export default function BookmarkFeeds() {
         axios.get(`${process.env.REACT_APP_API_HOST}/api/bookmarks?page=${pageNumber}`,
             {withCredentials: true})
             .then(({data}) => {
-                const newFeeds = [];
-                data.bookmarks.forEach((feed) => newFeeds.push(feed));
-                setBookmarks(presentFeeds => [...presentFeeds, ...newFeeds]);
+                setBookmarks(presentFeeds => {
+                    const present = JSON.stringify(presentFeeds);
+
+                    const feedsToPush = []
+                    data.bookmarks.forEach(feed => {
+                            if (!present.includes(JSON.stringify(feed))) {
+                                feedsToPush.push(feed)
+                            }
+                        }
+                    );
+                    return [...presentFeeds, ...feedsToPush];
+                });
+
+
                 pageNumber = data.nextPageable.pageNumber;
                 hasNext = data.hasNext;
                 loading = false;
                 setInit(false);
+
+                if (!hasNext) {
+                    document.getElementById('bottomNotifier').style.display = 'inherit';
+                }
             })
             .catch(error => {
                 console.log(error);
@@ -75,6 +90,8 @@ export default function BookmarkFeeds() {
                             ></Feed>
                         )
             }
+            <div id="bottomNotifier" style={{display: 'none', marginTop: 100, marginBottom: 200}}>더 이상 불러올 피드가 없습니다 🙌
+            </div>
         </>
     );
 }

--- a/frontend/src/views/DefaultFeeds.js
+++ b/frontend/src/views/DefaultFeeds.js
@@ -14,21 +14,26 @@ export default function DefaultFeeds() {
         axios.get(`${process.env.REACT_APP_API_HOST}/api/feeds?page=${pageNumber}`,
             {withCredentials: true})
             .then(({data}) => {
-                const newFeeds = [];
-                data.feedResponses.forEach((feed) => newFeeds.push(feed));
-                setFeeds(presentFeeds => [...presentFeeds, ...newFeeds]);
+                setFeeds(presentFeeds => {
+                    const present = JSON.stringify(presentFeeds);
+
+                    const feedsToPush = []
+                    data.feedResponses.forEach(feed => {
+                            if (!present.includes(JSON.stringify(feed))) {
+                                feedsToPush.push(feed)
+                            }
+                        }
+                    );
+                    return [...presentFeeds, ...feedsToPush];
+                });
+
                 pageNumber = data.nextPageable.pageNumber;
                 hasNext = data.hasNext;
                 loading = false;
                 setInit(false);
 
                 if (!hasNext) {
-                    setTimeout(() => {
-                        const aa = document.querySelectorAll('.MuiCard-root')
-                        const target = aa[aa.length - 1]
-                        console.log(target)
-                        target.style.marginBottom = '100px';
-                    }, 100)
+                    document.getElementById('bottomNotifier').style.display = 'inherit';
                 }
             })
             .catch(error => {
@@ -74,6 +79,8 @@ export default function DefaultFeeds() {
                         ></Feed>
                     )
             }
+            <div id="bottomNotifier" style={{display: 'none', marginTop: 100, marginBottom: 200}}>더 이상 불러올 피드가 없습니다 🙌
+            </div>
         </>
     );
 }

--- a/frontend/src/views/SubscribedFeeds.js
+++ b/frontend/src/views/SubscribedFeeds.js
@@ -5,7 +5,7 @@ import Feed from "../components/Feed";
 import {NavLink} from "react-router-dom";
 
 export default function SubscribedFeeds() {
-    const [feeds, setFeeds] = useState([]);
+    const [feeds, setFeeds] = useState(new Set());
     let pageNumber = 0;
     let loading = false;
     let hasNext = true;
@@ -15,21 +15,26 @@ export default function SubscribedFeeds() {
         axios.get(`${process.env.REACT_APP_API_HOST}/api/subscribes?page=${pageNumber}`,
             {withCredentials: true})
             .then(({data}) => {
-                const newFeeds = [];
-                data.feedResponses.forEach((feed) => newFeeds.push(feed));
-                setFeeds(presentFeeds => [...presentFeeds, ...newFeeds]);
+                setFeeds(presentFeeds => {
+                    const present = JSON.stringify(presentFeeds);
+
+                    const feedsToPush = []
+                    data.feedResponses.forEach(feed => {
+                            if (!present.includes(JSON.stringify(feed))) {
+                                feedsToPush.push(feed)
+                            }
+                        }
+                    );
+                    return [...presentFeeds, ...feedsToPush];
+                });
+
                 pageNumber = data.nextPageable.pageNumber;
                 hasNext = data.hasNext;
                 loading = false;
                 setInit(false);
 
                 if (!hasNext) {
-                    setTimeout(() => {
-                        const aa = document.querySelectorAll('.MuiCard-root')
-                        const target = aa[aa.length - 1]
-                        console.log(target)
-                        target.style.marginBottom = '100px';
-                    }, 100)
+                    document.getElementById('bottomNotifier').style.display = 'inherit';
                 }
             })
             .catch(error => {
@@ -84,6 +89,10 @@ export default function SubscribedFeeds() {
                             ></Feed>
                         )
             }
+            <div id="bottomNotifier"
+                 style={{display: 'none', marginTop: 100, marginBottom: 200}}>
+                더 이상 불러올 피드가 없습니다 🙌
+            </div>
         </>
     );
 }


### PR DESCRIPTION
## 요약

<img width="217" alt="image" src="https://user-images.githubusercontent.com/62681566/196156272-3153ec01-e252-42fe-98c2-47195cb9c2f5.png">

<br><br>

## 작업 내용

- 추가로 피드를 불러왔을 때 `hasNext`가 `false`일 경우, 최하단 div의 display값을 inherit으로 변경하여 표시 처리
- 추가로 피드를 불러왔을 때 중복 검증하는 로직에 있었던 오류 수정
  - 스크롤을 통한 추가 렌더링 + 페이지 이동 시 중복 렌더링 되던 이슈 해소
  - 기존 피드들을 JSON Stringify 하여 include로 검증처리
  - 성능 상 불리하나.. 성능 체감 보다는 버그를 잡는 것에 우선순위를 두는 게 마땅함

<br><br>

## 관련 이슈

- Close #5 
- Close #38 

<br><br>
