### PR TITLE
feat: 모니터링을 위한 액츄에이터 설정 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -29,9 +29,26 @@ repositories {
 
 dependencies {
     implementation 'org.jsoup:jsoup:1.15.3'
+    implementation 'com.rometools:rome:1.18.0'
+
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 
     implementation 'com.querydsl:querydsl-jpa:5.0.0'
     implementation 'com.querydsl:querydsl-apt:5.0.0'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    runtimeOnly 'mysql:mysql-connector-java'
+    implementation 'org.springframework.session:spring-session-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 
     testImplementation 'io.rest-assured:rest-assured:4.4.0'
     testImplementation 'io.rest-assured:spring-mock-mvc:4.4.0'
@@ -39,21 +56,6 @@ dependencies {
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'org.springframework.restdocs:spring-restdocs-restassured'
 
-    implementation 'com.rometools:rome:1.18.0'
-
-    implementation 'org.springframework.boot:spring-boot-starter-webflux'
-
-    implementation 'org.springframework.session:spring-session-data-redis'
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-    compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.h2database:h2'
-    runtimeOnly 'mysql:mysql-connector-java'
-    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
-    annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 


### PR DESCRIPTION
## 요약

![image](https://user-images.githubusercontent.com/62681566/197092979-99580937-8b9a-4faf-ba58-69c49acd95db.png)

- 스프링부트 애플리케이션 모니터링을 위한 액츄에이터 의존성 및 노출 정보 설정 추가
- 위 이미지는 예제 프로젝트로 진행한 예시 사진
- 힙 메모리, 스레드, GC, 로그 발생량 등 상세한 정보 확인 가능

<br><br>

## 작업 내용

- 액츄에이터, 프로메테우스 의존성 추가
- yaml파일에 노출할 정보 목록 추가

<br><br>

## 관련 이슈

- Close #45

<br><br>
