### PR TITLE
feat: EmbeddedRedis 추가, 프로파일 리팩터링

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -36,6 +36,8 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    implementation('it.ozimov:embedded-redis:0.7.3') { exclude group: "org.slf4j", module: "slf4j-simple" }
+    runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'
 
     implementation 'com.querydsl:querydsl-jpa:5.0.0'

--- a/backend/src/main/java/com/rssmanager/config/EmbeddedRedisConfig.java
+++ b/backend/src/main/java/com/rssmanager/config/EmbeddedRedisConfig.java
@@ -1,0 +1,30 @@
+package com.rssmanager.config;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import redis.embedded.RedisServer;
+
+@Profile({"test"})
+@Component
+public class EmbeddedRedisConfig {
+    private final RedisServer redisServer;
+
+    public EmbeddedRedisConfig(final RedisConfig redisConfig) {
+        this.redisServer = RedisServer.builder()
+                .port(redisConfig.getPort())
+                .setting("maxmemory 32MB")
+                .build();
+    }
+
+    @PostConstruct
+    public void start() {
+        redisServer.start();
+    }
+
+    @PreDestroy
+    public void stop() {
+        redisServer.stop();
+    }
+}

--- a/backend/src/main/java/com/rssmanager/config/RedisConfig.java
+++ b/backend/src/main/java/com/rssmanager/config/RedisConfig.java
@@ -19,15 +19,6 @@ public class RedisConfig {
     @Value("${spring.redis.password}")
     public String password;
 
-
-    @Bean
-    public RedisTemplate<String, String> redisTemplate(final RedisConnectionFactory connectionFactory) {
-        final var redisTemplate = new RedisTemplate<String, String>();
-        redisTemplate.setConnectionFactory(connectionFactory);
-
-        return redisTemplate;
-    }
-
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         final var configuration = new RedisStandaloneConfiguration();
@@ -36,5 +27,25 @@ public class RedisConfig {
         configuration.setPassword(this.password);
 
         return new LettuceConnectionFactory(configuration);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate(final RedisConnectionFactory connectionFactory) {
+        final var redisTemplate = new RedisTemplate<byte[], byte[]>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+
+        return redisTemplate;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public String getPassword() {
+        return password;
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,4 +1,72 @@
 spring:
   config:
-    import:
-      - classpath:/2022-MyRSS-secret/application.yml
+    import: optional:classpath:/2022-MyRSS-secret/application.yml
+
+  profiles:
+    active: test
+
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb
+    hikari:
+      maximum-pool-size: 10
+      connection-timeout: 5000
+      data-source-properties:
+        cachePrepStmts: true
+        prepStmtCacheSize: 250
+        prepStmtCacheSqlLimit: 2048
+        useServerPrepStmts: true
+        useLocalSessionState: true
+        rewriteBatchedStatements: true
+        cacheResultSetMetadata: true
+        cacheServerConfiguration: true
+        elideSetAutoCommits: true
+        maintainTimeStats: false
+
+  jpa:
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+        jdbc:
+          time_zone: Asia/Seoul
+    hibernate:
+      ddl-auto: create
+
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+  data:
+    redis:
+      repositories:
+        enabled: false
+
+  redis:
+    host: localhost
+    port: 6379
+    password:
+
+  session:
+    store-type: redis
+
+server:
+  tomcat:
+    max-connections: 400
+    accept-count: 50
+    threads:
+      min-spare: 10
+      max: 10
+
+oauth:
+  github:
+    accessTokenUrl: https://github.com/login/oauth/access_token
+    userInfoUrl: https://api.github.com/user
+    clientId:
+    clientSecret:
+
+logging:
+  level:
+    web: debug
+

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -2,6 +2,16 @@
 <configuration>
     <include resource="logback/logback-appenders.xml"/>
 
+    <springProfile name="test">
+        <logger name="com.rssmanager" level="DEBUG">
+            <appender-ref ref="CONSOLE"/>
+        </logger>
+
+        <logger name="org.springframework" level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </logger>
+    </springProfile>
+
     <springProfile name="local">
         <logger name="com.rssmanager" level="DEBUG">
             <appender-ref ref="CONSOLE"/>

--- a/backend/src/test/java/com/rssmanager/documentation/RssControllerTest.java
+++ b/backend/src/test/java/com/rssmanager/documentation/RssControllerTest.java
@@ -1,45 +1,60 @@
 package com.rssmanager.documentation;
 
-import org.junit.jupiter.api.Disabled;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+
+import com.rssmanager.member.domain.Member;
+import com.rssmanager.rss.domain.Rss;
+import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
 
 class RssControllerTest extends DocumentationTest {
-
-    @Disabled
     @Test
     void RSS_목록_조회() {
-//        when(rssService.findByMember(null)).thenReturn(
-//                List.of(
-//                        new Rss(1L, "화음을 좋아하는 리차드", "https://creampuffy.tistory.com/rss",
-//                                "https://creampuffy.tistory.com", "", false),
-//                        new Rss(2L, "D2 Blog", "https://d2.naver.com/d2.atom", "https://d2.naver.com",
-//                                "https://d2.naver.com/favicon.ico", true),
-//                        new Rss(3L, "우아한형제들 기술블로그", "https://techblog.woowahan.com/feed/",
-//                                "https://techblog.woowahan.com",
-//                                "https://techblog.woowahan.com/wp-content/uploads/2020/08/favicon.ico", true)
-//                )
-//        );
-//
-//        docsGiven
-//                .contentType(MediaType.APPLICATION_JSON_VALUE)
-//                .when().get("/api/rss")
-//                .then().log().all()
-//                .apply(document("rss/list",
-//                        responseFields(
-//                                fieldWithPath("rssResponses.[].id").type(JsonFieldType.NUMBER)
-//                                        .description("RSS id"),
-//                                fieldWithPath("rssResponses.[].title").type(JsonFieldType.STRING)
-//                                        .description("RSS title"),
-//                                fieldWithPath("rssResponses.[].rssUrl").type(JsonFieldType.STRING)
-//                                        .description("RSS rssUrl"),
-//                                fieldWithPath("rssResponses.[].link").type(JsonFieldType.STRING)
-//                                        .description("RSS link"),
-//                                fieldWithPath("rssResponses.[].iconUrl").type(JsonFieldType.STRING)
-//                                        .description("RSS iconUrl"),
-//                                fieldWithPath("rssResponses.[].recommended").type(JsonFieldType.BOOLEAN)
-//                                        .description("RSS recommended")
-//                        )
-//                ))
-//                .statusCode(HttpStatus.OK.value());
+        // given
+        final var richard = new Member(1L, 1L, "Richard", "image.png");
+        given(sessionManager.<Member>getAttribute("member")).willReturn(richard);
+
+        // when
+        when(rssService.findByMember(richard)).thenReturn(
+                List.of(
+                        new Rss(1L, "화음을 좋아하는 리차드", "https://creampuffy.tistory.com/rss",
+                                "https://creampuffy.tistory.com", "", false),
+                        new Rss(2L, "D2 Blog", "https://d2.naver.com/d2.atom", "https://d2.naver.com",
+                                "https://d2.naver.com/favicon.ico", true),
+                        new Rss(3L, "우아한형제들 기술블로그", "https://techblog.woowahan.com/feed/",
+                                "https://techblog.woowahan.com",
+                                "https://techblog.woowahan.com/wp-content/uploads/2020/08/favicon.ico", true)
+                )
+        );
+
+        // then
+        docsGiven
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().get("/api/rss")
+                .then().log().all()
+                .apply(document("rss/list",
+                        responseFields(
+                                fieldWithPath("rssResponses.[].id").type(JsonFieldType.NUMBER)
+                                        .description("RSS id"),
+                                fieldWithPath("rssResponses.[].title").type(JsonFieldType.STRING)
+                                        .description("RSS title"),
+                                fieldWithPath("rssResponses.[].rssUrl").type(JsonFieldType.STRING)
+                                        .description("RSS rssUrl"),
+                                fieldWithPath("rssResponses.[].link").type(JsonFieldType.STRING)
+                                        .description("RSS link"),
+                                fieldWithPath("rssResponses.[].iconUrl").type(JsonFieldType.STRING)
+                                        .description("RSS iconUrl"),
+                                fieldWithPath("rssResponses.[].recommended").type(JsonFieldType.BOOLEAN)
+                                        .description("RSS recommended")
+                        )
+                ))
+                .statusCode(HttpStatus.OK.value());
     }
 }


### PR DESCRIPTION
## 요약

- 보안이 필요한 프로파일 설정값을 담은 Submodule 없이 Clone해도 즉시 기동 가능하도록 개선
- 테스트에 사용될 EmbeddedRedis 설정 추가

<br><br>

## 작업 내용

- Submodule에 담긴 프로파일을 Optional로 import하도록 개선
- Submodule에 담긴 프로파일 없이 기동할 경우 H2, EmbeddedRedis 기반으로 동작하도록 구현

<br><br>

## 참고 사항

- [옵셔널 설정 임포트에 대한 스프링 공식문서](https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.external-config.files.optional-prefix)
- [EmbeddedRedis 사용관련 Baeldung 포스팅](https://www.baeldung.com/spring-embedded-redis)

<br><br>

## 관련 이슈

- Close #61 
- Close #62 

<br><br>
