### PR TITLE
refactor: Entity 클래스에 Index, ForeignKey 명시

### DIFF
--- a/backend/src/main/java/com/rssmanager/member/domain/Member.java
+++ b/backend/src/main/java/com/rssmanager/member/domain/Member.java
@@ -5,10 +5,13 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Table(indexes = @Index(name = "idx_member_provider_id", columnList = "providerId", unique = true))
 @Entity
 public class Member implements Serializable {
     @Id

--- a/backend/src/main/java/com/rssmanager/rss/domain/Bookmark.java
+++ b/backend/src/main/java/com/rssmanager/rss/domain/Bookmark.java
@@ -3,15 +3,19 @@ package com.rssmanager.rss.domain;
 import com.rssmanager.member.domain.Member;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Table(indexes = @Index(name = "idx_bookmark_member_id_feed_id", columnList = "memberId, feedId", unique = true))
 @Entity
 public class Bookmark {
     @Id
@@ -19,11 +23,11 @@ public class Bookmark {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "memberId")
+    @JoinColumn(name = "memberId", foreignKey = @ForeignKey(name = "fk_bookmark_member_id"))
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "feedId")
+    @JoinColumn(name = "feedId", foreignKey = @ForeignKey(name = "fk_bookmark_feed_id"))
     private Feed feed;
 
     protected Bookmark() {

--- a/backend/src/main/java/com/rssmanager/rss/domain/Feed.java
+++ b/backend/src/main/java/com/rssmanager/rss/domain/Feed.java
@@ -7,18 +7,21 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Table(indexes = @Index(name = "idx_feed_link", columnList = "link", unique = true))
 @Entity
 public class Feed {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String title;
-    @Column(length = 1000)
+    @Column(length = 750)
     private String link;
     private String description;
     private Date updateDate;

--- a/backend/src/main/java/com/rssmanager/rss/domain/Rss.java
+++ b/backend/src/main/java/com/rssmanager/rss/domain/Rss.java
@@ -4,10 +4,13 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Table(indexes = @Index(name = "idx_rss_rss_url", columnList = "rssUrl", unique = true))
 @Entity
 public class Rss {
     @Id

--- a/backend/src/main/java/com/rssmanager/rss/domain/Subscribe.java
+++ b/backend/src/main/java/com/rssmanager/rss/domain/Subscribe.java
@@ -3,15 +3,19 @@ package com.rssmanager.rss.domain;
 import com.rssmanager.member.domain.Member;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Table(indexes = @Index(name = "idx_subscribe_member_id_rss_id", columnList = "memberId, rssId", unique = true))
 @Entity
 public class Subscribe {
     @Id
@@ -19,11 +23,11 @@ public class Subscribe {
     private Long id;
 
     @ManyToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "memberId")
+    @JoinColumn(name = "memberId", foreignKey = @ForeignKey(name = "fk_subscribe_member_id"))
     private Member member;
 
     @ManyToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "rssId")
+    @JoinColumn(name = "rssId", foreignKey = @ForeignKey(name = "fk_subscribe_rss_id"))
     private Rss rss;
 
     public Subscribe() {

--- a/backend/src/test/java/com/rssmanager/documentation/DocumentationTest.java
+++ b/backend/src/test/java/com/rssmanager/documentation/DocumentationTest.java
@@ -24,7 +24,6 @@ import org.springframework.web.context.WebApplicationContext;
 @ExtendWith(RestDocumentationExtension.class)
 @WebMvcTest
 public class DocumentationTest {
-
     @MockBean
     protected RssService rssService;
     @MockBean


### PR DESCRIPTION
## 요약

- Entity 클래스 내 설정된 Index 및 ForeignKey 명시

<br><br>

## 작업 내용

- 모든 엔티티 내 인덱스 및 외래키 명시 처리
- 다대일 + 연관관계 주인인 Feed 엔티티의 경우 리팩터링 대상이라 외래키는 명시 생략

<br><br>

## 참고 사항

```java
@Table(indexes = @Index(name = "idx_subscribe_member_id_rss_id", columnList = "memberId, rssId", unique = true))
@Entity
public class Subscribe {
    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;

    @ManyToOne(fetch = FetchType.Lazy)
    @JoinColumn(name = "memberId", foreignKey = @ForeignKey(name = "fk_subscribe_member_id"))
    private Member member;

    @ManyToOne(fetch = FetchType.Lazy)
    @JoinColumn(name = "rssId", foreignKey = @ForeignKey(name = "fk_subscribe_rss_id"))
    private Rss rss;

    // ...
}
```

- [5차 요구사항 중 인덱스 설정 관련 진행한 내용 wiki](https://github.com/HJ-Rich/2022-MyRSS/wiki/fifth#%EC%84%9C%EB%B9%84%EC%8A%A4%EC%97%90%EC%84%9C-%EC%82%AC%EC%9A%A9%ED%95%98%EB%8A%94-%EC%BF%BC%EB%A6%AC%EB%A5%BC-%EC%A0%95%EB%A6%AC%ED%95%98%EA%B3%A0-%EA%B0%81-%EC%BF%BC%EB%A6%AC%EC%97%90%EC%84%9C-%EC%82%AC%EC%9A%A9%ED%95%98%EB%8A%94-%EC%9D%B8%EB%8D%B1%EC%8A%A4-%EC%84%A4%EC%A0%95)

<br><br>

## 관련 이슈

- Close #65 
<br><br>
