### PR TITLE
fix(EmbeddedRedisConfig): Jenkins 빌드 실패 대응

### DIFF
--- a/backend/src/main/java/com/rssmanager/config/EmbeddedRedisConfig.java
+++ b/backend/src/main/java/com/rssmanager/config/EmbeddedRedisConfig.java
@@ -14,12 +14,16 @@ public class EmbeddedRedisConfig {
     public EmbeddedRedisConfig(final RedisConfig redisConfig) {
         this.redisServer = RedisServer.builder()
                 .port(redisConfig.getPort())
-                .setting("maxmemory 32MB")
+                .setting("maxmemory 8MB")
                 .build();
     }
 
     @PostConstruct
     public void start() {
+        if (redisServer.isActive()) {
+            return;
+        }
+
         redisServer.start();
     }
 

--- a/backend/src/test/java/com/rssmanager/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/rssmanager/acceptance/AcceptanceTest.java
@@ -3,6 +3,7 @@ package com.rssmanager.acceptance;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.rssmanager.auth.controller.dto.LoginRequest;
+import com.rssmanager.config.EmbeddedRedisConfig;
 import com.rssmanager.support.DatabaseCleaner;
 import com.rssmanager.support.MockGithubExchange;
 import io.restassured.RestAssured;
@@ -10,6 +11,7 @@ import io.restassured.internal.RestAssuredResponseImpl;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.util.Collection;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.function.Executable;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,11 +32,19 @@ public class AcceptanceTest {
     private int port;
     @Autowired
     private DatabaseCleaner databaseCleaner;
+    @Autowired
+    private EmbeddedRedisConfig embeddedRedisConfig;
 
     @BeforeEach
     public void setUp() {
         RestAssured.port = port;
+        embeddedRedisConfig.start();
+    }
+
+    @AfterEach
+    public void tearDown() {
         databaseCleaner.clear();
+        embeddedRedisConfig.stop();
     }
 
     protected String 로그인() {


### PR DESCRIPTION
## 요약

- 로컬, Github Actions에서는 통과하나 Jenkins에서만 Embedded Redis 로 인해 테스트 실패
- 해당 테스트 실패 이슈 대응

<br><br>

## 작업 내용

- `@PostConstruct` 에서 EmbeddedRedis의 active 여부를 확인 후 실행하도록 수정
- 테스트의 BeforeEach, AfterEach에서 EmbeddedRedis를 매번 닫아주고 새로 열도록 수정

<br><br>

## 참고 사항

- https://hsik0225.github.io/redis/2021/12/05/Can't-start-redis-server/

<br><br>

