### PR TITLE
refactor(CorsConfig): 로컬 개발 환경에서만 Cors 허용이 적용되도록 개선

### DIFF
--- a/backend/src/main/java/com/rssmanager/config/CorsConfig.java
+++ b/backend/src/main/java/com/rssmanager/config/CorsConfig.java
@@ -1,10 +1,12 @@
 package com.rssmanager.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+@Profile({"test", "local"})
 @Configuration
 public class CorsConfig implements WebMvcConfigurer {
     public static final String ALLOWED_METHOD_NAMES = "GET,HEAD,POST,PUT,DELETE,TRACE,OPTIONS,PATCH";
@@ -12,7 +14,7 @@ public class CorsConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(final CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:3000", "https://dev.myrss.ga", "https://myrss.ga")
+                .allowedOrigins("http://localhost:3000")
                 .allowCredentials(true)
                 .allowedMethods(ALLOWED_METHOD_NAMES.split(","))
                 .exposedHeaders(HttpHeaders.LOCATION);


### PR DESCRIPTION
## 요약

- Cors 로컬 개발 환경에서만 허용하도록 개선

<br><br>

## 작업 내용

- withCredentials 및 allowedOrigin 설정이 local 또는 test 프로파일에서만 적용되도록 변경
- allowedOrigin 목록에 localhost:3000만 남기고 제거

<br><br>