### PR TITLE
refactor(axios): axios 공통 설정용 컴포넌트 추출

### DIFF
--- a/backend/src/main/java/com/rssmanager/member/controller/dto/MemberResponse.java
+++ b/backend/src/main/java/com/rssmanager/member/controller/dto/MemberResponse.java
@@ -1,6 +1,7 @@
 package com.rssmanager.member.controller.dto;
 
 import com.rssmanager.member.domain.Member;
+import java.util.Objects;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -18,6 +19,10 @@ public class MemberResponse {
     }
 
     public static MemberResponse from(final Member member) {
+        if (Objects.isNull(member)) {
+            return new MemberResponse(null, null, null);
+        }
+
         return MemberResponse.builder()
                 .id(member.getId())
                 .nickname(member.getName())

--- a/frontend/src/components/Feed.js
+++ b/frontend/src/components/Feed.js
@@ -16,8 +16,8 @@ export default function Feed(props) {
 
     const handleBookmark = () => {
         if (!bookmark) {
-            axios.post(`${process.env.REACT_APP_API_HOST}/api/bookmarks`,
-                {id: props.id}, {withCredentials: true})
+            axios.post(`/api/bookmarks`,
+                {id: props.id})
                 .then(({data}) => {
                     setOpen(true);
                     setBookmark(true);
@@ -25,8 +25,7 @@ export default function Feed(props) {
         }
 
         if (bookmark) {
-            axios.delete(`${process.env.REACT_APP_API_HOST}/api/bookmarks?feedId=${props.id}`,
-                {withCredentials: true})
+            axios.delete(`/api/bookmarks?feedId=${props.id}`)
                 .then(({data}) => {
                     setOpenUn(true);
                     setBookmark(false);

--- a/frontend/src/components/Profile.js
+++ b/frontend/src/components/Profile.js
@@ -4,8 +4,7 @@ import axios from "axios";
 
 export default function Profile(props) {
     function logoutHandler() {
-        axios.post(`${process.env.REACT_APP_API_HOST}/api/auth/invalidate`,
-            {}, {withCredentials: true})
+        axios.post(`/api/auth/invalidate`)
             .then(({data}) => window.location.href = '/')
     }
 

--- a/frontend/src/components/Rss.js
+++ b/frontend/src/components/Rss.js
@@ -10,8 +10,7 @@ export default function Rss() {
     const [init, setInit] = useState(true);
 
     useEffect(() => {
-        axios.get(`${process.env.REACT_APP_API_HOST}/api/rss`,
-            {withCredentials: true})
+        axios.get(`/api/rss`)
             .then(({data}) => {
                 setRss(data.rssResponses)
                 setInit(false);
@@ -25,9 +24,8 @@ export default function Rss() {
 
     const handleSubscribe = (e) => {
         const requestUrl = e.target.previousSibling.querySelector('input').value;
-        axios.post(`${process.env.REACT_APP_API_HOST}/api/subscribes`,
-            {url: requestUrl},
-            {withCredentials: true})
+        axios.post(`/api/subscribes`,
+            {url: requestUrl})
             .then(({data}) => {
                 location.reload();
             })

--- a/frontend/src/components/RssComponent.js
+++ b/frontend/src/components/RssComponent.js
@@ -6,16 +6,14 @@ import axios from "axios";
 export default function RssComponent(props) {
     const handleDelete = () => {
         axios.delete(
-            `${process.env.REACT_APP_API_HOST}/api/rss?id=${props.id}`,
-            {withCredentials: true})
+            `/api/rss?id=${props.id}`)
             .then(({data}) => {
                 location.reload()
             }).catch(error => console.log(error))
     }
 
     useEffect(() => {
-        axios.get(`${process.env.REACT_APP_API_HOST}/api/rss`,
-            {withCredentials: true})
+        axios.get(`/api/rss`)
             .then(({data}) => {
                 setRss(data.rssResponses)
                 setInit(false);

--- a/frontend/src/components/SubscribeModal.js
+++ b/frontend/src/components/SubscribeModal.js
@@ -17,8 +17,8 @@ export default function SubscribeModal() {
             return;
         }
 
-        axios.post(`${process.env.REACT_APP_API_HOST}/api/subscribes`,
-            {url: input}, {withCredentials: true})
+        axios.post(`/api/subscribes`,
+            {url: input})
             .then(({data}) => {
                 handleClose()
                 setOpenSuccess(true)

--- a/frontend/src/config/AxiosConfig.js
+++ b/frontend/src/config/AxiosConfig.js
@@ -1,0 +1,13 @@
+import axios from "axios";
+
+export default function axiosConfig() {
+    axios.defaults.baseURL = `${process.env.REACT_APP_API_HOST}`;
+    if (`${process.env.NODE_ENV}` === 'development') {
+        axios.defaults.withCredentials = true;
+    }
+    axios.defaults.timeout = 3000;
+    axios.interceptors.response.use(
+        (response) => response,
+        (error) => Promise.reject(error)
+    );
+}

--- a/frontend/src/views/App.js
+++ b/frontend/src/views/App.js
@@ -12,6 +12,7 @@ import Social from "./Social";
 import Bookmarks from "./Bookmarks";
 import ManageRss from "./ManageRss";
 import HowTo from "./HowTo";
+import axiosConfig from "../config/AxiosConfig";
 
 const darkTheme = createTheme({
     palette: {
@@ -22,10 +23,10 @@ const darkTheme = createTheme({
 function App() {
     const [loginStatus, setLoginStatus] = useState();
     const [userInfo, setUserInfo] = useState({});
+    axiosConfig();
 
     useEffect(() => {
-        axios.post(`${process.env.REACT_APP_API_HOST}/api/auth/certificate`,
-            {}, {withCredentials: true})
+        axios.post(`/api/auth/certificate`)
             .then(({data}) => {
                 setLoginStatus(data.loggedIn);
                 setUserInfo(data.member);

--- a/frontend/src/views/BookmarkFeeds.js
+++ b/frontend/src/views/BookmarkFeeds.js
@@ -13,8 +13,7 @@ export default function BookmarkFeeds() {
     const [init, setInit] = useState(true);
 
     const loadMoreFeeds = (() => {
-        axios.get(`${process.env.REACT_APP_API_HOST}/api/bookmarks?page=${pageNumber}`,
-            {withCredentials: true})
+        axios.get(`/api/bookmarks?page=${pageNumber}`)
             .then(({data}) => {
                 if (pageNumber === 0 && data.bookmarks.length === 0) {
                     isEmpty = true;

--- a/frontend/src/views/DefaultFeeds.js
+++ b/frontend/src/views/DefaultFeeds.js
@@ -11,8 +11,7 @@ export default function DefaultFeeds() {
     const [init, setInit] = useState(true);
 
     const loadMoreFeeds = (() => {
-        axios.get(`${process.env.REACT_APP_API_HOST}/api/feeds?page=${pageNumber}`,
-            {withCredentials: true})
+        axios.get(`/api/feeds?page=${pageNumber}`)
             .then(({data}) => {
                 setFeeds(presentFeeds => {
                     const present = JSON.stringify(presentFeeds);

--- a/frontend/src/views/OAuthGithubCallback.js
+++ b/frontend/src/views/OAuthGithubCallback.js
@@ -6,14 +6,8 @@ export default function OAuthGithubCallback() {
     const [searchParams] = useSearchParams();
     const code = searchParams.get("code");
 
-    axios.post(`${process.env.REACT_APP_API_HOST}/api/auth/login`,
-        {
-            code: code
-        },
-        {
-            headers: {"Content-Type": "application/json"},
-            withCredentials: true
-        }
+    axios.post(`/api/auth/login`,
+        {code: code}
     ).then(({data}) => {
         window.location.href = '/'
     });

--- a/frontend/src/views/SubscribedFeeds.js
+++ b/frontend/src/views/SubscribedFeeds.js
@@ -12,8 +12,7 @@ export default function SubscribedFeeds() {
     const [init, setInit] = useState(true);
 
     const loadMoreFeeds = (() => {
-        axios.get(`${process.env.REACT_APP_API_HOST}/api/subscribes?page=${pageNumber}`,
-            {withCredentials: true})
+        axios.get(`/api/subscribes?page=${pageNumber}`)
             .then(({data}) => {
                 if (pageNumber === 0 && data.feedResponses.length === 0) {
                     isEmpty = true;


### PR DESCRIPTION
## 요약

- axios 공통 설정 추출

<br><br>

## 작업 내용

- axios 객체에 withCredentials 설정을 로컬 개발 시에만 true로 적용하도록 개선
  - 개발서버, 운영서버에서는 Same-Origin을 준수하기에 불필요한 설정임
- 전역 baseUrl 설정을 통해 프론트 프로덕션 코드에서 /api/** 와 같은 형태의 주소만 작성하면 되도록 개선
- 전역 타임아웃 3초 설정

<br><br>

## 참고 사항

- https://axios-http.com/kr/docs/req_config 

<br><br>

## 관련 이슈

- Close #50

<br><br>
